### PR TITLE
May 31 updates

### DIFF
--- a/content/agencies/index.md
+++ b/content/agencies/index.md
@@ -13,7 +13,7 @@ picto:
 
 FedRAMP provides a standardized, reusable approach to security assessment and authorization for cloud computing products and services used by federal agencies. Federal agencies are
 required by both [the law](../authority/law/agencies.md){ data-preview } and [OMB policy](../authority/m-24-15/roles.md) to follow the processes and rules established by FedRAMP
-for the use of cloud services in agency information systems. This authority builds on "FISMA" requirements in the law and policy and may not be ignored;
+when using cloud services in agency information systems. This authority builds on "FISMA" requirements in the law and policy and may not be ignored;
 [M-24-15](../authority/m-24-15/implementation.md){ data-preview } explicitly requires agencies to update their agency policies to align with FedRAMP.
 
 !!! tip "FedRAMP was established to support agency mission delivery by standardizing how agencies use commercial cloud services."
@@ -22,6 +22,17 @@ for the use of cloud services in agency information systems. This authority buil
     framework for using commercial cloud services within federal information systems that lowers the burden for adoption
     significantly. FedRAMP is not an oversight or enforcement body, it exists to be the primary point of connection between
     agencies and commercial services to enable adoption.
+
+!!! danger "Oversight and enforcement is still performed!"
+
+    Failure to follow processes outlined by FedRAMP, in alignment with the law and policy, will expose agency officials
+    to audit by the Office of Management and Budget, Inspectors General, and the Government Accountability Office.
+    FedRAMP has participated in multiple audits by each of these bodies that has resulted in findings against agencies
+    for following legacy processes or failing to properly adopt FedRAMP processes.
+
+    A [March 2026 Best Practices for Cloud Computing](https://www.ignet.gov/sites/default/files/files/CIGIE-OIG%20Best%20Practices%20for%20Cloud%20Computing.pdf)
+    report from the Council of the Inspectors General highlights many failures by agencies to meet their responsibilities
+    for the use of cloud services.
 
 ---
 

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -9,6 +9,60 @@ picto:
 
 # Changelog
 
+## 2026.05.31.01-preview
+
+**Release Date:** May 31, 2026
+
+### Rules Changes
+
+The following changes were made in [pull request #12](https://github.com/FedRAMP/rules/pull/12) to the [FedRAMP Machine-Readable Rules](https://github.com/FedRAMP/rules) repository, which is used by this repository for machine-generated content:
+
+- `FRD-FMV` adds the alternate term `fully mitigate vulnerabilities`.
+- `FRD-PMV` adds the alternate term `partially mitigate vulnerabilities`.
+- `FRD-RMV` adds the alternate term `remediate vulnerabilities`.
+- `AGU-USE-NFC` is renamed from `Notify FedRAMP of Concerns` to `Notify FedRAMP of Monitoring Concerns`.
+- `CCM-AGM-NFR` was removed from Continuous Collaborative Monitoring.
+- `CCM-AGM-NPC` was removed from Continuous Collaborative Monitoring.
+- `CCM-OCR-RPS` is renamed from `Responsible Public Sharing` to `Responsible Public Certification Report Sharing`.
+- `CDS-CSO-RPS` is renamed from `Responsible Public Sharing` to `Responsible Public Package Sharing`.
+- `CDS-TRC-HMR` is renamed from `Human and Machine-Readable` to `Human and Machine-Readable Certification Data`.
+- `CDS-UTC-PGD` is renamed from `Public Guidance` to `Public Guidance for Certification Data`.
+- `FRC-CLA-AFR` updates its following-information display reference for `CDS-UTC-PGD` to use `Public Guidance for Certification Data`.
+- Structural: `FRC-CSF-PMV` moved from `FRR.FRC.data.rev5.CSF` to new rule `VDR-TFR-MVF` under `FRR.VDR.data.rev5.TFR`, preserving the Rev5 class-specific persistent machine verification and validation cadence.
+- Structural: `FRC-CSX-PMV` moved from `FRR.FRC.data.20x.CSX` to new rule `VDR-TFR-MVX` under `FRR.VDR.data.20x.TFR`, preserving the 20x class-specific persistent machine verification and validation cadence.
+- Structural: `FRC-CSO-NMV` moved from `FRR.FRC.data.all.CSO` to new rule `VDR-TFR-NMV` under `FRR.VDR.data.all.TFR`, preserving the non-machine verification and validation requirement.
+- Structural: `FRC-CSO-FAV` moved from `FRR.FRC.data.all.CSO` to new rule `VDR-CSO-FAV` under `FRR.VDR.data.all.CSO`, with the statement narrowed to failures in vulnerability detection and response processes.
+- `FRC-CSO-PVV` was removed as a standalone FRC rule; structurally, the persistent verification and validation concept is now incorporated into `VDR-CSO-DET`.
+- `SCG-CSO-PUB` is renamed from `Public Guidance` to `Public Secure Configuration Guidance`.
+- `SCN-CSO-HRM` is renamed from `Human and Machine-Readable` to `Human and Machine-Readable Notifications`.
+- `VDR-CSO-DET` expands vulnerability detection to include penetration testing, incident response, automated control testing, and persistent verification and validation of information resources and processes.
+- `VDR-CSO-FAV` adds the VDR rule requiring providers to treat problems or failures with vulnerability detection and response processes as vulnerabilities.
+- `VDR-CSO-RES` converts a single note into expanded notes that distinguish partial mitigation, full mitigation, and remediation, and adds the corresponding FRD terms.
+- `VDR-TFR-IRI` updates class-specific incident-treatment wording to use `Partially Mitigated Vulnerability` terminology for internet-reachable likely exploitable vulnerabilities at N3 or below.
+- `VDR-TFR-NRI` updates class-specific incident-treatment wording to use `Partially Mitigated Vulnerability` terminology for non-internet-reachable likely exploitable vulnerabilities at N4 or below.
+- `VDR-TFR-PVR` updates class-specific vulnerability response wording to use the defined partial mitigation, full mitigation, and remediation terms without changing the PAIN timeframes.
+
+### Content Updates
+
+- [Federal Agencies](https://preview.fedramp.gov/2026/agencies/): Clarified that agencies must follow FedRAMP processes when using cloud services and added an oversight warning with a March 2026 CIGIE cloud computing report link.
+- [The Federal Risk and Authorization Management Program](https://preview.fedramp.gov/2026/responsibilities/): Added guidance for pointing AI services at FedRAMP source data and corrected the responsibilities link to the consolidated rules page.
+- [Choosing a Certification Class](https://preview.fedramp.gov/2026/providers/start/class/): Replaced the placeholder with stable guidance on how Certification Classes scale by assurance, investment, federal process maturity, and agency use cases.
+- [Choosing a Certification Type](https://preview.fedramp.gov/2026/providers/start/type/): Replaced the placeholder with stable guidance comparing 20x and Rev5, including when providers should use each option and how Rev5 is expected to be retired.
+- [Choosing a Certification Path](https://preview.fedramp.gov/2026/providers/start/path/): Replaced the placeholder with stable guidance explaining Program Certification and Agency Certification, including which combinations are required, limited, or unavailable.
+
+### Site Structure
+
+- Replaced the multi-page FedRAMP responsibilities navigation with one [FedRAMP's Responsibilities](https://preview.fedramp.gov/2026/responsibilities/rules/) page that groups FedRAMP-specific rules in one place.
+
+### Generated Page Experience
+
+- Added support for generated FRR collection pages, allowing selected rules from multiple rulesets to appear together on one page. Example: [FedRAMP's Responsibilities](https://preview.fedramp.gov/2026/responsibilities/rules/).
+- Updated the stable-status pictograph color to a darker green for better contrast and readability.
+
+### Tooling
+
+- Added generator tests and documentation for FRR collection pages, related-rule links, generated references, deadline output, and rendered page smoke checks.
+
 ## 2026.05.25.01-preview
 
 **Release Date:** May 25, 2026

--- a/content/providers/start/class.md
+++ b/content/providers/start/class.md
@@ -1,11 +1,95 @@
 ---
 description: "Overview of the classes, explanations that it's good to progress through them, and where to start and how to proceed through them with a focus on starting class."
 purpose: "Folks will know they should start at Class A and not try to go straight to Class D or something bonkers like that."
-google_doc: "https://docs.google.com/document/d/16nRI1Sr3oAxriPB-y-6aOSG5BttCcxV4go3_NEQD7Mc/edit?tab=t.12ikucvmjzbv"
+google_doc: ""
 picto:
   source: person
-  status: empty
+  status: stable
 ---
 
 # Choosing a Certification Class
 
+FedRAMP Classes are designed to be undertaken progressively where your investment can scale with agency interest and resource availability. The further the class progression, the greater the level of assurance and commitment to federal agency customers.
+
+FedRAMP Certification requires additional work and focus, both initially and ongoing, for even the most mature security programs. These unique expectations and considerations are designed to translate
+commercial security best practices into requirements that government agencies understand and ensure that consistent ongoing assurance is supplied in the same way so that government customers
+can meet their many legal, regulatory, and policy requirements for operating federal information systems securely.
+
+Each FedRAMP Certification Class provides progressively more assurance, commitment, and alignment with diverse agency needs; this requires additional preparation, familiarity with the federal process, and investment at every stage.
+
+| Area of Impact | Class A | Class B | Class C | Class D |
+| -- | -- | -- | -- | -- |
+| Preparation | :material-star-box-outline:{ .lg .middle .machine } | :material-star-box-outline:{ .lg .middle .person }:material-star-box-outline:{ .lg .middle .person }:material-star-box-outline:{ .lg .middle .person }| :material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle } |:material-star-box-outline:{ .lg .middle .empty }:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}  |
+| Federal Process Maturity | :material-star-box-outline:{ .lg .middle .machine }:material-star-box-outline:{ .lg .middle .machine } | :material-star-box-outline:{ .lg .middle  .person}:material-star-box-outline:{ .lg .middle .person } | :material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }  | :material-star-box-outline:{ .lg .middle .empty }:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty} |
+| Automation | :material-star-box-outline:{ .lg .middle .machine } | :material-star-box-outline:{ .lg .middle .person } | :material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle } | :material-star-box-outline:{ .lg .middle .empty }:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}  |
+| Verification and Validation | :material-star-box-outline:{ .lg .middle .machine } | :material-star-box-outline:{ .lg .middle .person }:material-star-box-outline:{ .lg .middle .person } | :material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }  |:material-star-box-outline:{ .lg .middle .empty }:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}  |
+| Agency Assurance | :material-star-box-outline:{ .lg .middle .machine } |:material-star-box-outline:{ .lg .middle .person }:material-star-box-outline:{ .lg .middle .person } |:material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle }:material-star-box-outline:{ .lg .middle } |:material-star-box-outline:{ .lg .middle .empty }:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty}:material-star-box-outline:{ .lg .middle .empty} |
+| Cost | :lucide-circle-dollar-sign:{ .lg .middle .machine } | :lucide-circle-dollar-sign:{ .lg .middle .person }:lucide-circle-dollar-sign:{ .lg .middle .person } | :lucide-circle-dollar-sign:{ .lg .middle }:lucide-circle-dollar-sign:{ .lg .middle }:lucide-circle-dollar-sign:{ .lg .middle } | :lucide-circle-dollar-sign:{ .lg .middle .empty }:lucide-circle-dollar-sign:{ .lg .middle .empty }:lucide-circle-dollar-sign:{ .lg .middle .empty }:lucide-circle-dollar-sign:{ .lg .middle .empty }:lucide-circle-dollar-sign:{ .lg .middle .empty} |
+
+!!! tip "Start with FedRAMP Class A Certification"
+
+    In most situations, cloud service providers that are looking to enter the federal market should start with a FedRAMP Class A Certification, which
+    is designed for existing commercial products that already have a SOC 2 Type II certification and a mature security program.
+
+!!! warning "Be careful starting with FedRAMP Class C or Class D Certification!"
+
+    Cloud service providers generally should not go straight to FedRAMP Class C or Class D Certification unless they have an existing
+    contract with a government agency that requires this level of commitment. These Certification Classes are intended for providers
+    with an active customer base who have already invested in a federal compliance program.
+
+## Decision Workflow
+
+```mermaid
+flowchart TD
+  start([Choosing a Class])
+  existing{Do you have an existing FedRAMP Certification?}
+  higher[Invest in a higher class based on what your agency customers need and are willing to pay for.]
+  agency{Do you have existing agency customers that require FedRAMP Certification?}
+  lowest[Invest in the lowest starting class that meets the agency requirements and your business fit.]
+  classA[Class A is the simplest way to get FedRAMP Certified to obtain a customer.]
+
+  start --> existing
+  existing -->|Yes| higher
+  existing -->|No| agency
+  agency -->|Yes| lowest
+  agency -->|No| classA
+```
+## What about Low, Moderate, and High?
+
+Federal agencies categorize their information systems following the [NIST Federal Information Processing Standards
+for Security Categorization of Federal Information and Information Systems](https://csrc.nist.gov/pubs/fips/199/final) (FIPS Publication 199).
+FIPS 199 defines security categories of low impact, moderate impact, and high impact, based on the potential impact to the agency from a loss of confidentiality,
+integrity, or available of the information in the system. [NIST Federal Information Processing Standards for Minimum
+Security Requirements for Federal Information and Information Systems](https://csrc.nist.gov/pubs/fips/200/final) (FIPS Publication 200)
+requires federal agencies to set the overall impact level of a system at the highest security categorization of the
+three security objectives, then employ appropriately tailored controls.
+
+FedRAMP Certification Classes loosely align with the baseline security expectations for these impact levels as outlined in [NIST SP 800-53B Control Baselines
+for Information Systems and Organizations](https://csrc.nist.gov/pubs/sp/800/53/b/upd1/final). There is not a direct
+correlation between FedRAMP Certification Class and Impact Level for the following key reasons:
+
+1. Cloud service providers may tailor controls within the baseline to increase or reduce their focus on different security objectives; not all baselines are implemented the same.
+
+2. Agencies may include services with lower or higher security categorizations inside their federal information system by tailoring the control baseline, establishing compensating controls, or controlling information flow within the system to ensure components operate safely with different security categorizations than the overall system.
+
+!!! warning "Commercial cloud services are not usually federal information systems!"
+
+    Cloud services used by federal agencies are usually a component within a federal information system, but the cloud service
+    itself is not subject to laws, regulations, or policies for federal information systems unless it is built by the
+    government or under explicit contract where the provider operates the service on behalf of the government.
+
+    In most cases, commercial cloud services are simply a service that is used by a federal information system and should
+    not be considered an information system operated on behalf of the government.
+
+### Alignment with Agency Use Cases
+
+In general, the FedRAMP Certification Classes are designed to provide the minimum assurance necessary for an
+authorizing official to make a determination to include the service in a federal information system at a
+specific impact level, as follows:
+
+| FedRAMP Certification Class | Agency Usage |
+| -- | -- |
+| Class A | Class A Certifications include adequate information for most non-sensitive use cases and some Low, Moderate, or High security objectives. |
+| Class B | Class B Certifications include adequate information for most Low security objectives and some Moderate or High security objectives. |
+| Class C | Class C Certifications include adequate information for most Low and Moderate security objectives, as well as some High security objectives. |
+| Class D | Class D Certifications include adequate information for most use cases regardless of security objective (this does not include systems that process classified information).|

--- a/content/providers/start/path.md
+++ b/content/providers/start/path.md
@@ -1,11 +1,40 @@
 ---
 description: "Overview of the Certification paths and how to choose one, including depending on the type and class expectations."
 purpose: "Folks know they should aim for Program Certification on 20x unless they need a Class D before early 2027."
-google_doc: "https://docs.google.com/document/d/16nRI1Sr3oAxriPB-y-6aOSG5BttCcxV4go3_NEQD7Mc/edit?tab=t.ec4zb857i0rd"
+google_doc: ""
 picto:
   source: person
-  status: empty
+  status: stable
 ---
 
 # Choosing a Certification Path
 
+There are two FedRAMP Certification Paths:
+
+- **Program Certification** is provided directly by FedRAMP and does not require a federal agency to "sponsor" the service for FedRAMP Certification; this path is mostly only available for the 20x Certification Type.
+- **Agency Certification** requires a federal agency to authorize the service in advance, following the legacy FedRAMP process, then "sponsor" the service for FedRAMP Certification; this path is only available for the Rev5 Certification Type.
+
+!!! tip "You may combine FedRAMP Certification Paths for Rev5."
+
+    Cloud service providers may obtain a FedRAMP Rev5 Class A Certification via the Program Certification Path
+    then later use the Agency Certification Path to upgrade to a different FedRAMP Rev5 Certification Class.
+
+## Choice is a Misnomer
+
+In general, you do not get to choose a Certification Path because it is the outcome of your other choices. This section
+is more about awareness than choice.
+
+| Type | Class | Program Certification | Agency Certification |
+| -- | -- | -- | -- |
+| 20x | Class A | :lucide-badge-check:{ .xl .middle .stable } Required | :lucide-circle-slash:{ .xl .middle .empty } Unavailable|
+| 20x | Class B |  :lucide-badge-check:{ .xl .middle .stable } Required | :lucide-circle-slash:{ .xl .middle .empty } Unavailable|
+| 20x | Class C |  :lucide-badge-check:{ .xl .middle .stable } Required | :lucide-circle-slash:{ .xl .middle .empty } Unavailable|
+| 20x | Class D |  :lucide-badge-check:{ .xl .middle .stable } Required | :lucide-circle-slash:{ .xl .middle .empty } Unavailable|
+| Rev5 | Class A | :lucide-badge-check:{ .xl .middle .stable } Required | :lucide-circle-slash:{ .xl .middle .empty } Unavailable|
+| Rev5 | Class B | :lucide-circle-dashed:{ .xl .middle .placeholder } Limited| :lucide-badge-check:{ .xl .middle .stable } Expected|
+| Rev5 | Class C | :lucide-circle-dashed:{ .xl .middle .placeholder } Limited| :lucide-badge-check:{ .xl .middle .stable } Expected|
+| Rev5 | Class D | :lucide-circle-slash:{ .xl .middle .empty } Unavailable | :lucide-badge-check:{ .xl .middle .stable } Required|
+
+!!! danger "Program Certifications are limited to one type, either 20x or Rev5."
+
+    FedRAMP will not provide Program Certifications for both 20x and Rev5 as this is an inefficient use of FedRAMP's limited resources.

--- a/content/providers/start/type.md
+++ b/content/providers/start/type.md
@@ -1,11 +1,45 @@
 ---
 description: "Overview of the certification types and how to choose one, with a focus on choosing since there's a lot more information in the Overview section on types."
 purpose: "Folks will know they should go 20x unless they want Class D before early 2027 or they run their own infrastructure."
-google_doc: "https://docs.google.com/document/d/16nRI1Sr3oAxriPB-y-6aOSG5BttCcxV4go3_NEQD7Mc/edit?tab=t.b7bcr5j0nhy0"
+google_doc: ""
 picto:
   source: person
-  status: empty
+  status: stable
 ---
 
 # Choosing a Certification Type
 
+There are two FedRAMP Certification Types:
+
+- **20x** is a modern cloud-native approach that is new in 2026.
+- **Rev5** is a modified version of the legacy approach that will be retired in the future.
+
+## FedRAMP 20x vs Rev5
+
+In general, cloud service offerings that are built on FedRAMP Certified infrastructure or platforms should choose FedRAMP 20x; this is the fastest, cheapest,
+and best way to bring an existing commercial cloud service into the federal market. It's new in 2026, but is designed to be the future of FedRAMP Certification
+and will be the only option for most cloud services soon. FedRAMP 20x Certifications are processed directly by FedRAMP and do not require an active agency
+contract or sponsor.
+
+FedRAMP Rev5 is a modified version of the legacy FedRAMP Certification process that encouraged companies to build and operate government-specific services. It
+requires significant additional investment in time and effort compared to FedRAMP 20x, but is currently the only option for cloud services that run their own
+infrastructure or require a FedRAMP Class D Certification. FedRAMP Rev5 Certifications typically require an active agency contract or sponsor in advance.
+
+!!! tip "FedRAMP 20x Class D Certifications will be available in 2027"
+
+    FedRAMP anticipates piloting 20x Class D Certifications in late 2026 and making them available
+    as a formal option in early 2027. In most cases, a cloud service provider entering the federal
+    market from zero today will be able to obtain a FedRAMP 20x Class C Certification then upgrade
+    to a FedRAMP 20x Class D Certification faster than obtaining a FedRAMP Rev5 Class D Certification.
+
+| FedRAMP 20x | FedRAMP Rev5 |
+| -- | -- |
+| **Modern** Certification Type | **Legacy** Certification Type |
+| Intended for cloud-native services built on FedRAMP Certified infrastructure or platforms. | Intended for standalone services entirely owned and operated by the cloud service provider. |
+| Designed for use over the next decade with continuous improvement. | Will be retired by FedRAMP as a new Certification Type by mid-2027 and may be retired as an ongoing Certification Type in the future. |
+| Encourages government adoption of commercial cloud service offerings and discourages separate government-only versions. | Typically implemented with a separate government-only version of the cloud service. |
+| Program Certification available for Class A, Class B, and Class C. | Program Certification only available for Class A; all others typically require an agency sponsor. |
+
+!!! danger "FedRAMP Rev5 will be retired."
+
+    Consider carefully before investing in a FedRAMP Certification Type that FedRAMP is actively working to replace and retire over the next few years.

--- a/content/responsibilities/index.md
+++ b/content/responsibilities/index.md
@@ -86,7 +86,7 @@ intended to be a snapshot that will apply throughout the effective period for th
 
     Review the specific rules that FedRAMP has created for our involvement in certain processes to understand our commitment to consistency.
 
-    [FedRAMP's Responsibilities](fedramp-certification.md){ data-preview }
+    [FedRAMP's Responsibilities](rules.md){ data-preview }
 
 -   :lucide-gavel:{ .xl .middle .empty } **Who put FedRAMP in charge?**
 

--- a/content/responsibilities/index.md
+++ b/content/responsibilities/index.md
@@ -21,6 +21,15 @@ The Consolidated Rules for 2026 reflect that vision, establishing a full new set
     of that historical information no longer applies after FedRAMP was rescinded and replaced in 2024. Stakeholders should be extremely
     careful to avoid outdated information, especially that provided by Large Language Models and AI services.
 
+!!! tip "Point AI services at the source material for FedRAMP Rules"
+
+    The [Source Data](../sources.md) page in the Overview contains links to the raw source data used to
+    generate the FedRAMP Consolidated Rules for 2026. Each of the repositories that contain source data
+    also contain instructions for AI Agents to help them process this information.
+
+    Whenever possible, the original [Source Data](../sources.md) should be explicitly specified with
+    any AI service to ensure it is primary source of truth.
+
 ---
 
 <!--

--- a/overrides/stylesheets/extra.css
+++ b/overrides/stylesheets/extra.css
@@ -12,7 +12,7 @@
 }
 
 .stable {
-  color: #b0f539;
+  color: #008642;
 }
 
 .placeholder {

--- a/tools/README.md
+++ b/tools/README.md
@@ -311,26 +311,33 @@ Generated rule pages also support selected rich rule metadata:
 - `reference_url_web_name` links a rule reference to another generated ruleset page through `rulesHref`.
 - `pain_timeframes` renders a PAIN timeframe table inside applicable rule variants.
 
-For example, this mapping processes every FRR and generates one page per rule family for rules that affect FedRAMP:
+The default template is `templates/template.hbs`, with partials in `templates/partials/`. New templates can use the same view model as the default template: effective entries, flows, sections, requirements, definitions, and requirement metadata such as terms, controls, notes, examples, and references.
+
+## Generated FRR Collection Pages
+
+Add an entry to `generated.frrCollectionDocuments` in `config.json` when selected rules from multiple FRR rulesets should be combined into one page:
 
 ```json
 {
   "id": "fedramp-responsibilities",
-  "output": "responsibilities/{FRR}.md",
-  "outputMode": "documents",
+  "title": "FedRAMP's Responsibilities",
+  "output": "responsibilities/rules.md",
+  "status": "placeholder",
   "definitionsHref": "../definitions/",
   "rulesHref": "../",
   "emptyBehavior": "skip",
-  "includeEffectiveDates": false,
   "source": {
     "collection": "FRR",
     "documents": "ALL",
     "types": ["20x", "rev5"],
     "affects": ["FedRAMP"],
+    "sections": ["FRP"],
     "includeAll": true,
     "allPosition": "first"
   }
 }
 ```
 
-The default template is `templates/template.hbs`, with partials in `templates/partials/`. New templates can use the same view model as the default template: effective entries, flows, sections, requirements, definitions, and requirement metadata such as terms, controls, notes, examples, and references.
+FRR collection mappings output a single Markdown page. Each matched FRR ruleset renders as a `##` section with the FRR purpose, then the matching subset description, then the rules selected by `source.affects` and `source.sections`. These collection pages intentionally omit effective-date blocks and activity workflow diagrams.
+
+Mapping fields are the same as generated rule pages except `title` is required, `outputMode`, `includeEffectiveDates`, and `source.groupBy` are not used, and `status` controls the overall page pictograph status directly.

--- a/tools/config.json
+++ b/tools/config.json
@@ -109,6 +109,26 @@
         }
       }
     ],
+    "frrCollectionDocuments": [
+      {
+        "id": "fedramp-responsibilities",
+        "title": "FedRAMP's Responsibilities",
+        "output": "responsibilities/rules.md",
+        "status": "placeholder",
+        "definitionsHref": "../definitions/",
+        "rulesHref": "../",
+        "emptyBehavior": "skip",
+        "source": {
+          "collection": "FRR",
+          "documents": "ALL",
+          "types": ["20x", "rev5"],
+          "affects": ["FedRAMP"],
+          "sections": ["FRP"],
+          "includeAll": true,
+          "allPosition": "first"
+        }
+      }
+    ],
     "ruleDocuments": [
       {
         "id": "complete-ruleset-reference",
@@ -123,24 +143,6 @@
           "collection": "FRR",
           "documents": "ALL",
           "types": ["20x", "rev5"],
-          "includeAll": true,
-          "allPosition": "first"
-        }
-      },
-      {
-        "id": "fedramp-responsibilities",
-        "output": "responsibilities/{FRR}.md",
-        "outputMode": "documents",
-        "status": "stable",
-        "definitionsHref": "../definitions/",
-        "rulesHref": "../",
-        "emptyBehavior": "skip",
-        "includeEffectiveDates": false,
-        "source": {
-          "collection": "FRR",
-          "documents": "ALL",
-          "types": ["20x", "rev5"],
-          "affects": ["FedRAMP"],
           "includeAll": true,
           "allPosition": "first"
         }

--- a/tools/scripts/build-markdown.test.ts
+++ b/tools/scripts/build-markdown.test.ts
@@ -26,6 +26,7 @@ import {
   loadToolConfig,
   REPO_ROOT,
   resolveToolPath,
+  type RuleType,
   type ToolConfig,
 } from "./config";
 import { deploy } from "./deploy";
@@ -249,6 +250,350 @@ function expectTextOrder(
       previousIndex = index;
     }
   });
+}
+
+type RulesForTest = Awaited<ReturnType<typeof loadRules>>;
+type RequirementDocumentForTest = RulesForTest["FRR"][string];
+type RequirementEntryForTest =
+  NonNullable<
+    NonNullable<RequirementDocumentForTest["data"]["all"]>[string]
+  >[string];
+type RuleBucketForTest = "all" | RuleType;
+type ArtifactForTest = ReturnType<typeof collectArtifacts>[number];
+
+function markdownTableCell(value: string): string {
+  return value.replace(/\s+/g, " ").replace(/\|/g, "\\|").trim();
+}
+
+function humanizeStatus(value?: string): string {
+  if (!value) {
+    return "Unknown";
+  }
+
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function slugifyTerm(term: string): string {
+  return term
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+function slugifyHeading(heading: string): string {
+  return slugifyTerm(heading.replace(/&/g, " and "));
+}
+
+function mermaidNodeId(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return `node_${normalized || "unnamed"}`;
+}
+
+function mermaidQuotedValue(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\r", " ")
+    .replaceAll("\n", "<br/>");
+}
+
+function relatedTermsGroupAnchorId(tag: string): string {
+  return `related-terms-group-${slugifyTerm(tag)}`;
+}
+
+function documentSubsetCount(document: RequirementDocumentForTest): number {
+  const subsetKeys = new Set<string>();
+
+  for (const bucket of Object.values(document.data)) {
+    for (const subsetKey of Object.keys(bucket ?? {})) {
+      subsetKeys.add(subsetKey);
+    }
+  }
+
+  return subsetKeys.size;
+}
+
+function documentRuleCount(document: RequirementDocumentForTest): number {
+  const ruleIds = new Set<string>();
+
+  for (const bucket of Object.values(document.data)) {
+    for (const requirements of Object.values(bucket ?? {})) {
+      for (const ruleId of Object.keys(requirements ?? {})) {
+        ruleIds.add(ruleId);
+      }
+    }
+  }
+
+  return ruleIds.size;
+}
+
+function latestRequirementUpdateDate(
+  document: RequirementDocumentForTest,
+): string {
+  const dates: string[] = [];
+
+  for (const bucket of Object.values(document.data)) {
+    for (const requirements of Object.values(bucket ?? {})) {
+      for (const requirement of Object.values(requirements ?? {})) {
+        for (const change of requirement.updated ?? []) {
+          if (change.date) {
+            dates.push(change.date);
+          }
+        }
+      }
+    }
+  }
+
+  return dates.sort().at(-1) ?? "";
+}
+
+function expectedReferenceIndexRows(rules: RulesForTest): string[] {
+  return Object.values(rules.FRR)
+    .map((document) => {
+      const acronym = markdownTableCell(document.info.short_name ?? "");
+      const name = markdownTableCell(document.info.name);
+      const href = `${document.info.web_name}.md`;
+      const status = markdownTableCell(humanizeStatus(document.info.status));
+      const counts = `Subsets: ${documentSubsetCount(
+        document,
+      )}<br>Rules: ${documentRuleCount(document)}`;
+      const updated = markdownTableCell(latestRequirementUpdateDate(document));
+
+      return {
+        acronym,
+        row: `| ${acronym} | [${name}](${href}) | ${status} | ${counts} | ${updated} |`,
+      };
+    })
+    .sort((left, right) => left.acronym.localeCompare(right.acronym))
+    .map((entry) => entry.row);
+}
+
+function expectedImportantRelatedTermRows(rules: RulesForTest): string[] {
+  const taggedTerms = new Map<string, string[]>();
+
+  for (const entry of Object.values(rules.FRD.data.all ?? {})) {
+    const tag = entry.tag?.trim();
+    if (!tag) {
+      continue;
+    }
+
+    const terms = taggedTerms.get(tag) ?? [];
+    terms.push(entry.term);
+    taggedTerms.set(tag, terms);
+  }
+
+  return Array.from(taggedTerms.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([tag, terms]) => {
+      const linkedTerms = terms
+        .sort((left, right) => left.localeCompare(right))
+        .map((term) => `[${term}](#${slugifyTerm(term)}){ data-preview }`)
+        .join("<br>");
+
+      return `| <span id="${relatedTermsGroupAnchorId(
+        tag,
+      )}"></span>${tag} | ${linkedTerms} |`;
+    });
+}
+
+function matchesAffectedParties(
+  requirement: RequirementEntryForTest,
+  affects: string[],
+): boolean {
+  if (!affects.length) {
+    return true;
+  }
+
+  return (requirement.affects ?? []).some((affectedParty) =>
+    affects.some(
+      (allowedParty) =>
+        allowedParty.toLowerCase() === affectedParty.toLowerCase(),
+    ),
+  );
+}
+
+function firstRuleSelection(
+  document: RequirementDocumentForTest | undefined,
+  bucketNames: RuleBucketForTest[],
+  affects: string[] = [],
+): {
+  id: string;
+  requirement: RequirementEntryForTest;
+  bucketName: RuleBucketForTest;
+  subsetKey: string;
+} {
+  if (!document) {
+    throw new Error("Expected source document to exist in rules JSON.");
+  }
+
+  for (const bucketName of bucketNames) {
+    const bucket = document.data[bucketName];
+    if (!bucket) {
+      continue;
+    }
+
+    for (const [subsetKey, requirements] of Object.entries(bucket)) {
+      for (const [id, requirement] of Object.entries(requirements)) {
+        if (matchesAffectedParties(requirement, affects)) {
+          return { id, requirement, bucketName, subsetKey };
+        }
+      }
+    }
+  }
+
+  throw new Error(
+    `Expected ${document.info.short_name ?? document.info.name} to include a ${bucketNames.join(
+      "/",
+    )} rule${affects.length ? ` affecting ${affects.join(", ")}` : ""}.`,
+  );
+}
+
+function firstRuleId(
+  document: RequirementDocumentForTest | undefined,
+  bucketNames: RuleBucketForTest[],
+  affects: string[] = [],
+): string {
+  return firstRuleSelection(document, bucketNames, affects).id;
+}
+
+function subsetTitle(
+  document: RequirementDocumentForTest | undefined,
+  bucketName: RuleBucketForTest,
+  subsetKey: string,
+): string {
+  if (!document) {
+    throw new Error("Expected source document to exist in rules JSON.");
+  }
+
+  const versionSubset =
+    bucketName === "all"
+      ? undefined
+      : document.info[bucketName]?.subsets?.[subsetKey];
+
+  return (
+    versionSubset?.name ?? document.info.subsets?.[subsetKey]?.name ?? subsetKey
+  );
+}
+
+function firstRuleIdsByBucket(
+  document: RequirementDocumentForTest | undefined,
+): string[] {
+  if (!document) {
+    throw new Error("Expected source document to exist in rules JSON.");
+  }
+
+  const ids = new Set<string>();
+  for (const bucketName of Object.keys(document.data) as RuleBucketForTest[]) {
+    ids.add(firstRuleSelection(document, [bucketName]).id);
+  }
+
+  return Array.from(ids);
+}
+
+function findArtifact(
+  artifacts: ArtifactForTest[],
+  relativePath: string,
+): ArtifactForTest {
+  const artifact = artifacts.find((entry) => entry.relativePath === relativePath);
+  if (!artifact) {
+    throw new Error(`Expected generated artifact: ${relativePath}`);
+  }
+
+  return artifact;
+}
+
+function deadlineRowMarkdown(row: {
+  shortName: string;
+  name: string;
+  href: string;
+  obtain: string;
+  maintain: string;
+  graceEnds: string;
+}): string {
+  return `| ${row.shortName} | [${row.name}](${row.href}) | ${row.obtain} | ${row.maintain} | ${row.graceEnds} |`;
+}
+
+function controlUrl(controlId: string): string {
+  if (controlId.includes(".")) {
+    const [main = "", sub = ""] = controlId.split(".");
+    const [prefix = "", number = ""] = main.split("-");
+
+    return `https://controlfreak.risk-redux.io/controls/${prefix.toUpperCase()}-${number.padStart(
+      2,
+      "0",
+    )}(${sub.padStart(2, "0")})`;
+  }
+
+  const [prefix = "", number = ""] = controlId.split("-");
+  return `https://controlfreak.risk-redux.io/controls/${prefix.toUpperCase()}-${number.padStart(
+    2,
+    "0",
+  )}`;
+}
+
+function expectDeadlineRowsFromArtifact(
+  contents: string,
+  artifact: ArtifactForTest,
+  description: string,
+): void {
+  const expectedRows = artifact.context.deadlineTables.flatMap((table) =>
+    table.rows.map(deadlineRowMarkdown),
+  );
+  expect(expectedRows.length).toBeGreaterThan(0);
+
+  expectTextOrder(contents, expectedRows, description);
+}
+
+function expectNoDeadlineRowsForDocuments(
+  contents: string,
+  rules: RulesForTest,
+  documentKeys: string[],
+): void {
+  for (const documentKey of documentKeys) {
+    const shortName = rules.FRR[documentKey]?.info.short_name;
+    if (shortName) {
+      expect(contents).not.toContain(`| ${shortName} |`);
+    }
+  }
+}
+
+function testRequirementDocument(options: {
+  name: string;
+  shortName: string;
+  webName: string;
+  affects: string[];
+}): RequirementDocumentForTest {
+  return {
+    info: {
+      name: options.name,
+      short_name: options.shortName,
+      web_name: options.webName,
+      status: "stable",
+      effective: {
+        is: "required",
+        date: {
+          obtain: "2026-01-01",
+          maintain: "2026-02-01",
+          grace_ends: "2026-03-01",
+        },
+      },
+    },
+    data: {
+      all: {
+        GEN: {
+          [`${options.shortName}-GEN-ONE`]: {
+            name: "Synthetic Requirement",
+            statement: "Synthetic requirement used by tests.",
+            affects: options.affects,
+          },
+        },
+      },
+    },
+  };
 }
 
 async function git(args: string[], cwd = REPO_ROOT): Promise<string> {
@@ -974,49 +1319,60 @@ describe("build-markdown", () => {
     expect(referenceIndexContents).toContain(
       "| Acronym | Ruleset | Status | Counts | Most Recently Updated |",
     );
-    expect(referenceIndexContents).toContain(
-      "| FRC | [FedRAMP Certification](fedramp-certification.md) | Placeholder | Subsets: 9<br>Rules: 45 | 2026-05-04 |",
-    );
-    expect(referenceIndexContents).toContain(
-      "| SDR | [Security Decision Record](security-decision-record.md) | Empty | Subsets: 0<br>Rules: 0 |  |",
-    );
-    expect(referenceIndexContents).toContain(
-      "| AGU | [Agency Use of FedRAMP Certified Cloud Services (Needs Review)](agency-use.md) | Placeholder | Subsets: 3<br>Rules: 18 | 2026-05-04 |",
+    expectTextOrder(
+      referenceIndexContents,
+      expectedReferenceIndexRows(rules),
+      "Generated reference index should render source-derived rows in acronym order",
     );
 
     const referenceFrcContents = await readFile(
       path.join(OUTPUT_DIR, "reference", "fedramp-certification.md"),
       "utf8",
     );
+    const fedrampCertificationName = rules.FRR.FRC?.info.name;
+    expect(fedrampCertificationName).toBeTruthy();
     expect(referenceFrcContents).toStartWith(
-      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# FedRAMP Certification`,
+      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# ${fedrampCertificationName}`,
     );
-    expect(referenceFrcContents).toContain("FRC-CSX-SUM");
-    expect(referenceFrcContents).toContain("FRC-CSF-CDE");
-    expect(referenceFrcContents).toContain("FRC-FRP-MCM");
+    for (const ruleId of firstRuleIdsByBucket(rules.FRR.FRC)) {
+      expect(referenceFrcContents).toContain(ruleId);
+    }
     expect(referenceFrcContents).toContain("../definitions/#");
-    expect(referenceFrcContents).toContain(
-      "[MAS-CSO-IIR (Identify Information Resources)](minimum-assessment-scope.md#identify-information-resources){ data-preview }",
-    );
 
     const definitionsContents = await readFile(
       path.join(OUTPUT_DIR, "definitions.md"),
       "utf8",
     );
     const definitionsPurpose = rules.FRD.info.purpose;
+    const definitionHeaders = Array.from(
+      definitionsContents.matchAll(/^## (.+)$/gm),
+      (match) => match[1],
+    ).filter((heading) => heading !== "Important Related Terms");
+    const definitionTerms = Object.values(rules.FRD.data.all ?? {})
+      .map((entry) => entry.term)
+      .sort((left, right) => left.localeCompare(right));
+    const relatedTermRows = expectedImportantRelatedTermRows(rules);
+    const definitionIntroOrder = [
+      "# FedRAMP Definitions",
+      definitionsPurpose ?? "",
+    ];
+    if (relatedTermRows.length) {
+      definitionIntroOrder.push(
+        "## Important Related Terms",
+        "| Related Terms Group | Terms |",
+      );
+    }
+    if (definitionTerms[0]) {
+      definitionIntroOrder.push(`## ${definitionTerms[0]}`);
+    }
+
     expect(definitionsPurpose).toBeTruthy();
     expect(definitionsContents).toStartWith(
       `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${STABLE_STATUS_SPAN}\n\n# FedRAMP Definitions`,
     );
     expectTextOrder(
       definitionsContents,
-      [
-        "# FedRAMP Definitions",
-        definitionsPurpose ?? "",
-        "## Important Related Terms",
-        "| Related Terms Group | Terms |",
-        "## Accepted Vulnerability",
-      ],
+      definitionIntroOrder,
       "Generated FRD markdown should place info.purpose and related terms table before the definitions",
     );
     expect(definitionsContents).not.toContain("**Subsets**");
@@ -1028,25 +1384,40 @@ describe("build-markdown", () => {
     expect(definitionsContents).toContain('!!! quote ""');
     expect(definitionsContents).not.toContain("## General Terms");
     expect(definitionsContents).not.toContain("## Related Terms:");
-    expect(definitionsContents).toContain(
-      '| <span id="related-terms-group-vulnerability"></span>Vulnerability | [Accepted Vulnerability](#accepted-vulnerability){ data-preview }<br>[False Positive Vulnerability](#false-positive-vulnerability){ data-preview }',
+    for (const row of relatedTermRows) {
+      expect(definitionsContents).toContain(row);
+    }
+    const firstTaggedDefinition = Object.values(rules.FRD.data.all ?? {}).find(
+      (entry) => entry.tag?.trim(),
     );
-    expect(definitionsContents).toContain(
-      "**Related Terms Group:** [Vulnerability](#related-terms-group-vulnerability)",
-    );
-    const definitionHeaders = Array.from(
-      definitionsContents.matchAll(/^## (.+)$/gm),
-      (match) => match[1],
-    ).filter((heading) => heading !== "Important Related Terms");
-    const definitionTerms = Object.values(rules.FRD.data.all ?? {})
-      .map((entry) => entry.term)
-      .sort((left, right) => left.localeCompare(right));
+    if (firstTaggedDefinition?.tag) {
+      expect(definitionsContents).toContain(
+        `**Related Terms Group:** [${firstTaggedDefinition.tag}](#${relatedTermsGroupAnchorId(
+          firstTaggedDefinition.tag,
+        )})`,
+      );
+    }
     expect(definitionHeaders).toEqual(definitionTerms);
 
     const ksiArtifactPaths = relativePaths.filter((relativePath) =>
       relativePath.startsWith("providers/20x/key-security-indicators/"),
     );
     expect(ksiArtifactPaths).toHaveLength(Object.keys(rules.KSI).length);
+
+    const changeManagementTheme = Object.values(rules.KSI).find(
+      (theme) => theme.web_name === "change-management",
+    );
+    if (!changeManagementTheme) {
+      throw new Error(
+        'Expected a KSI theme with web_name "change-management" in the rules JSON.',
+      );
+    }
+    const [changeManagementIndicatorId, changeManagementIndicator] =
+      Object.entries(changeManagementTheme.indicators)[0] ?? [];
+    if (!changeManagementIndicatorId || !changeManagementIndicator) {
+      throw new Error("Expected Change Management to include a KSI indicator.");
+    }
+    const changeManagementControl = changeManagementIndicator.controls?.[0];
 
     const ksiChangeManagementContents = await readFile(
       path.join(
@@ -1059,22 +1430,27 @@ describe("build-markdown", () => {
       "utf8",
     );
     expect(ksiChangeManagementContents).toStartWith(
-      `---\ntags:\n  - 20x\n---\n\n${STABLE_STATUS_SPAN}\n\n# Change Management`,
+      `---\ntags:\n  - 20x\n---\n\n${STABLE_STATUS_SPAN}\n\n# ${changeManagementTheme.name}`,
     );
-    expect(ksiChangeManagementContents).toContain("# Change Management");
+    expect(ksiChangeManagementContents).toContain(
+      `# ${changeManagementTheme.name}`,
+    );
     expect(ksiChangeManagementContents).not.toContain("**Subsets**");
     expect(ksiChangeManagementContents).not.toContain('!!! info ""');
-    expect(ksiChangeManagementContents).toContain("KSI-CMT-LMC");
-    expect(ksiChangeManagementContents).toContain("### Logging Changes");
+    expect(ksiChangeManagementContents).toContain(changeManagementIndicatorId);
     expect(ksiChangeManagementContents).toContain(
-      "**Related SP 800-53 Controls:**",
+      `### ${changeManagementIndicator.name ?? changeManagementIndicatorId}`,
     );
-    expect(ksiChangeManagementContents).toContain(
-      "[AU-2](https://controlfreak.risk-redux.io/controls/AU-02)",
-    );
-    expect(ksiChangeManagementContents).toContain(
-      "../../../definitions/#cloud-service-offering",
-    );
+    if (changeManagementControl) {
+      expect(ksiChangeManagementContents).toContain(
+        "**Related SP 800-53 Controls:**",
+      );
+      expect(ksiChangeManagementContents).toContain(
+        `[${changeManagementControl.toUpperCase()}](${controlUrl(
+          changeManagementControl,
+        )})`,
+      );
+    }
     const ksiPolicyInventoryContents = await readFile(
       path.join(
         OUTPUT_DIR,
@@ -1085,13 +1461,20 @@ describe("build-markdown", () => {
       ),
       "utf8",
     );
-    expect(ksiPolicyInventoryContents).toContain("KSI-PIY-RES");
-    expect(ksiPolicyInventoryContents).toContain(
-      "[Persistently](../../../definitions/#persistently){ data-preview }",
+    const policyInventoryTheme = Object.values(rules.KSI).find(
+      (theme) => theme.web_name === "policy-and-inventory",
     );
-    expect(ksiPolicyInventoryContents).not.toContain(
-      "[Provider](../../../definitions/#provider){ data-preview }",
-    );
+    if (!policyInventoryTheme) {
+      throw new Error(
+        'Expected a KSI theme with web_name "policy-and-inventory" in the rules JSON.',
+      );
+    }
+    const [policyInventoryIndicatorId] =
+      Object.entries(policyInventoryTheme.indicators)[0] ?? [];
+    if (!policyInventoryIndicatorId) {
+      throw new Error("Expected Policy and Inventory to include a KSI indicator.");
+    }
+    expect(ksiPolicyInventoryContents).toContain(policyInventoryIndicatorId);
 
     const deadlines20xPath = path.join(
       OUTPUT_DIR,
@@ -1101,27 +1484,27 @@ describe("build-markdown", () => {
       "20x.md",
     );
     const deadlines20xContents = await readFile(deadlines20xPath, "utf8");
+    const providerDeadlineIgnoredDocuments =
+      (config.generated.deadlineDocuments ?? []).find(
+        (mapping) => mapping.id === "provider-important-deadlines",
+      )?.source.ignoreDocuments ?? [];
     expectFileToStartWith(
       deadlines20xPath,
       deadlines20xContents,
       `---\ntags:\n  - 20x\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# 20x Deadlines`,
       "Generated provider 20x deadlines markdown has an unexpected header",
     );
-    expect(deadlines20xContents).toContain(
-      "| FRC | [FedRAMP Certification](../../20x/rules/fedramp-certification.md) | 2026-07-04 | 2027-05-04 | 2027-05-04 |",
+    expectDeadlineRowsFromArtifact(
+      deadlines20xContents,
+      findArtifact(expectedArtifacts, "providers/updating/deadlines/20x.md"),
+      "Generated provider 20x deadlines should render source-derived rows in artifact order",
     );
-    expect(deadlines20xContents).not.toContain("| AGU |");
-    expect(deadlines20xContents).not.toContain("| REC |");
+    expectNoDeadlineRowsForDocuments(
+      deadlines20xContents,
+      rules,
+      providerDeadlineIgnoredDocuments,
+    );
     expect(deadlines20xContents).not.toContain("Rev5 Deadlines");
-    expect(
-      deadlines20xContents.indexOf(
-        "| SCG | [Secure Configuration Guide](../../20x/rules/secure-configuration-guide.md) | 2026-03-01 | 2026-03-01 | 2026-07-01 |",
-      ),
-    ).toBeLessThan(
-      deadlines20xContents.indexOf(
-        "| MKT | [Marketplace Listing](../../20x/rules/marketplace-listing.md) | 2026-07-04 | 2027-01-01 | 2027-05-04 |",
-      ),
-    );
 
     const deadlinesRev5Contents = await readFile(
       path.join(OUTPUT_DIR, "providers", "updating", "deadlines", "rev5.md"),
@@ -1130,27 +1513,26 @@ describe("build-markdown", () => {
     expect(deadlinesRev5Contents).toStartWith(
       `---\ntags:\n  - Rev5\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# Rev5 Deadlines`,
     );
-    expect(deadlinesRev5Contents).toContain(
-      "| FRC | [FedRAMP Certification](../../rev5/rules/fedramp-certification.md) | 2027-01-01 | 2027-01-01 | 2027-01-01 |",
+    expectDeadlineRowsFromArtifact(
+      deadlinesRev5Contents,
+      findArtifact(expectedArtifacts, "providers/updating/deadlines/rev5.md"),
+      "Generated provider Rev5 deadlines should render source-derived rows in artifact order",
     );
-    expect(deadlinesRev5Contents).toContain(
-      "| MAS | [Minimum Assessment Scope](../../rev5/rules/minimum-assessment-scope.md) | 2027-01-01 | 2027-01-01 | Within 2 months of the next annual assessment after 2027-01-01 |",
+    expectNoDeadlineRowsForDocuments(
+      deadlinesRev5Contents,
+      rules,
+      providerDeadlineIgnoredDocuments,
     );
-    expect(deadlinesRev5Contents).not.toContain("| REC |");
     expect(deadlinesRev5Contents).not.toContain("20x Deadlines");
 
     const assessorDeadlines20xContents = await readFile(
       path.join(OUTPUT_DIR, "assessors", "updating", "deadlines", "20x.md"),
       "utf8",
     );
-    expect(assessorDeadlines20xContents).toContain(
-      "| FRC | [FedRAMP Certification](../../20x/rules/fedramp-certification.md) |",
-    );
-    expect(assessorDeadlines20xContents).toContain(
-      "| MKT | [Marketplace Listing](../../recognition/rules/marketplace-listing.md) |",
-    );
-    expect(assessorDeadlines20xContents).toContain(
-      "| REC | [FedRAMP Recognition of Independent Assessment Services](../../recognition/rules/fedramp-recognition.md) |",
+    expectDeadlineRowsFromArtifact(
+      assessorDeadlines20xContents,
+      findArtifact(expectedArtifacts, "assessors/updating/deadlines/20x.md"),
+      "Generated assessor 20x deadlines should render source-derived rows in artifact order",
     );
     expect(assessorDeadlines20xContents).not.toContain(
       "../../../providers/20x/rules/",
@@ -1160,11 +1542,10 @@ describe("build-markdown", () => {
       path.join(OUTPUT_DIR, "assessors", "updating", "deadlines", "rev5.md"),
       "utf8",
     );
-    expect(assessorDeadlinesRev5Contents).toContain(
-      "| FRC | [FedRAMP Certification](../../rev5/rules/fedramp-certification.md) |",
-    );
-    expect(assessorDeadlinesRev5Contents).toContain(
-      "| REC | [FedRAMP Recognition of Independent Assessment Services](../../recognition/rules/fedramp-recognition.md) |",
+    expectDeadlineRowsFromArtifact(
+      assessorDeadlinesRev5Contents,
+      findArtifact(expectedArtifacts, "assessors/updating/deadlines/rev5.md"),
+      "Generated assessor Rev5 deadlines should render source-derived rows in artifact order",
     );
     expect(assessorDeadlinesRev5Contents).not.toContain(
       "../../../providers/rev5/rules/",
@@ -1187,43 +1568,53 @@ describe("build-markdown", () => {
       "utf8",
     );
     const fedrampCertificationPurpose = rules.FRR.FRC?.info.purpose;
+    const provider20xCommonRule = firstRuleSelection(rules.FRR.FRC, ["all"], [
+      "Providers",
+    ]);
+    const provider20xSpecificRule = firstRuleSelection(rules.FRR.FRC, ["20x"], [
+      "Providers",
+    ]);
+    const providerRev5SpecificRuleId = firstRuleId(rules.FRR.FRC, ["rev5"], [
+      "Providers",
+    ]);
+    const provider20xCommonSubsetTitle = subsetTitle(
+      rules.FRR.FRC,
+      provider20xCommonRule.bucketName,
+      provider20xCommonRule.subsetKey,
+    );
+    const provider20xSpecificSubsetTitle = subsetTitle(
+      rules.FRR.FRC,
+      provider20xSpecificRule.bucketName,
+      provider20xSpecificRule.subsetKey,
+    );
     expect(fedrampCertificationPurpose).toBeTruthy();
     expect(provider20xContents).toStartWith(
-      `---\ntags:\n  - 20x\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# FedRAMP Certification`,
+      `---\ntags:\n  - 20x\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# ${fedrampCertificationName}`,
     );
     expectTextOrder(
       provider20xContents,
       [
-        "# FedRAMP Certification",
+        `# ${fedrampCertificationName}`,
         fedrampCertificationPurpose ?? "",
         "**Subsets**",
-        "- [General Provider Responsibilities](#general-provider-responsibilities)",
-        "- [20x-Specific Provider Responsibilities](#20x-specific-provider-responsibilities)",
+        `- [${provider20xCommonSubsetTitle}](#${slugifyHeading(
+          provider20xCommonSubsetTitle,
+        )})`,
+        `- [${provider20xSpecificSubsetTitle}](#${slugifyHeading(
+          provider20xSpecificSubsetTitle,
+        )})`,
         "\n---",
-        "## General Provider Responsibilities {#general-provider-responsibilities}",
+        `## ${provider20xCommonSubsetTitle} {#${slugifyHeading(
+          provider20xCommonSubsetTitle,
+        )}}`,
       ],
       "Generated FRR markdown should place info.purpose and a multi-section TOC before the first body rule",
     );
-    expect(provider20xContents).toContain("# FedRAMP Certification");
-    expect(provider20xContents).toContain("FRC-CSO-CDS");
-    expect(provider20xContents).toContain("FRC-CSX-SUM");
-    expect(provider20xContents).not.toContain("FRC-CSF-CDE");
+    expect(provider20xContents).toContain(`# ${fedrampCertificationName}`);
+    expect(provider20xContents).toContain(provider20xCommonRule.id);
+    expect(provider20xContents).toContain(provider20xSpecificRule.id);
+    expect(provider20xContents).not.toContain(providerRev5SpecificRuleId);
     expect(provider20xContents).toContain("../../../definitions/#");
-    expect(provider20xContents).toContain(
-      "[Certification Data](../../../definitions/#certification-data){ data-preview }",
-    );
-    expect(provider20xContents).not.toContain(
-      "[Provider](../../../definitions/#provider){ data-preview }",
-    );
-    expect(provider20xContents).toContain(
-      "[FRC-CSO-POP (Pick One Program Certification Type)](#pick-one-program-certification-type){ data-preview }",
-    );
-    expect(provider20xContents).toContain(
-      "[MAS-CSO-IIR (Identify Information Resources)](minimum-assessment-scope.md#identify-information-resources){ data-preview }",
-    );
-    expect(provider20xContents).toContain(
-      "[CCM-OCR-NRD (Next Report Date)](collaborative-continuous-monitoring.md#next-report-date){ data-preview }",
-    );
 
     const providerRev5Contents = await readFile(
       path.join(
@@ -1236,10 +1627,10 @@ describe("build-markdown", () => {
       "utf8",
     );
     expect(providerRev5Contents).toStartWith(
-      `---\ntags:\n  - Rev5\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# FedRAMP Certification`,
+      `---\ntags:\n  - Rev5\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# ${fedrampCertificationName}`,
     );
-    expect(providerRev5Contents).toContain("FRC-CSF-CDE");
-    expect(providerRev5Contents).not.toContain("FRC-CSX-SUM");
+    expect(providerRev5Contents).toContain(providerRev5SpecificRuleId);
+    expect(providerRev5Contents).not.toContain(provider20xSpecificRule.id);
 
     const provider20xIcpContents = await readFile(
       path.join(
@@ -1251,59 +1642,62 @@ describe("build-markdown", () => {
       ),
       "utf8",
     );
+    const providerIcpRules = rules.FRR.ICP?.data.all?.CSO ?? {};
+    const incidentFlow = rules.FRR.ICP?.info.flows?.[0];
+    if (!incidentFlow?.steps?.length) {
+      throw new Error("Expected ICP to include a workflow in the rules JSON.");
+    }
+    const firstRuleStep = incidentFlow.steps.find(
+      (step) => step.to && providerIcpRules[step.to],
+    );
+    if (!firstRuleStep?.from || !firstRuleStep.to) {
+      throw new Error(
+        "Expected ICP workflow to include a step from a start node to a rule.",
+      );
+    }
+    const firstWorkflowRule = providerIcpRules[firstRuleStep.to];
+    if (!firstWorkflowRule?.name) {
+      throw new Error(
+        `Expected ICP workflow rule ${firstRuleStep.to} to exist in the provider rules.`,
+      );
+    }
+    const firstWorkflowStartNode = mermaidNodeId(firstRuleStep.from);
+    const firstWorkflowRuleNode = mermaidNodeId(firstRuleStep.to);
     expect(provider20xIcpContents).toContain(
-      "## Activity Workflow: Incident Communications",
+      `## Activity Workflow: ${incidentFlow.activity ?? "Flow 1"}`,
     );
     expect(provider20xIcpContents).toContain("``` mermaid");
     expect(provider20xIcpContents).toContain("flowchart TD");
-    const providerIcpRules = rules.FRR.ICP?.data.all?.CSO ?? {};
-    const federalReportabilityName = providerIcpRules["ICP-CSO-EFR"]?.name;
-    const federalImpactName = providerIcpRules["ICP-CSO-EFI"]?.name;
-    const defaultPainName = providerIcpRules["ICP-CSO-DPR"]?.name;
-    expect(federalReportabilityName).toBeTruthy();
-    expect(federalImpactName).toBeTruthy();
-    expect(defaultPainName).toBeTruthy();
     expect(provider20xIcpContents).toContain(
-      `node_icp_cso_efr{"ICP-CSO-EFR<br/>${federalReportabilityName}"}`,
+      `${firstRuleStep.to}<br/>${firstWorkflowRule.name}`,
     );
     expect(provider20xIcpContents).toContain(
-      'node_an_incident_is_identified(["An incident is identified."])',
-    );
-    expect(provider20xIcpContents).toContain(
-      `node_icp_cso_efi{"ICP-CSO-EFI<br/>${federalImpactName}"}`,
-    );
-    expect(provider20xIcpContents).toContain(
-      `node_icp_cso_dpr("ICP-CSO-DPR<br/>${defaultPainName}")`,
+      `${firstWorkflowStartNode}(["${mermaidQuotedValue(firstRuleStep.from)}"])`,
     );
     expect(provider20xIcpContents).toMatch(
-      /node_an_incident_is_identified -->(\|"[^"]+"\|)? node_icp_cso_efr/,
+      new RegExp(
+        `${firstWorkflowStartNode} -->(\\|"[^"]+"\\|)? ${firstWorkflowRuleNode}`,
+      ),
     );
     expect(provider20xIcpContents).toContain(
-      'click node_icp_cso_efr href "#',
+      `click ${firstWorkflowRuleNode} href "#`,
     );
     expect(provider20xIcpContents).toContain(
-      '"Jump to ICP-CSO-EFR"',
+      `"Jump to ${firstRuleStep.to}"`,
     );
-    const agencyNotification = providerIcpRules[
-      "ICP-CSO-IIR"
-    ]?.notification?.find(
-      (notification) => notification.party === "Agency Customers",
+    const notificationRule = Object.values(providerIcpRules).find((rule) =>
+      rule.notification?.some(
+        (notification) =>
+          notification.party && notification.method && notification.target,
+      ),
     );
-    expect(agencyNotification).toBeTruthy();
+    const notification = notificationRule?.notification?.find(
+      (entry) => entry.party && entry.method && entry.target,
+    );
+    expect(notificationRule).toBeTruthy();
+    expect(notification).toBeTruthy();
     expect(provider20xIcpContents).toContain(
-      `Notify ${agencyNotification?.party} by ${agencyNotification?.method} using ${agencyNotification?.target}.`,
-    );
-    expect(provider20xIcpContents).toContain(
-      "1. Contact information for the federal incident response coordinator.",
-    );
-    expect(provider20xIcpContents).toContain(
-      "following the rule in [ICP-CSO-EFI (Estimate Federal Impact)](#estimate-federal-impact){ data-preview }",
-    );
-    expect(provider20xIcpContents).toContain(
-      "following the requirements in [ICP-CSO-EFI (Estimate Federal Impact)](#estimate-federal-impact){ data-preview }",
-    );
-    expect(provider20xIcpContents).toContain(
-      "assigned a default PAIN-5 as required by [ICP-CSO-DPR (Default PAIN Rating)](#default-pain-rating){ data-preview }",
+      `Notify ${notification?.party} by ${notification?.method} using ${notification?.target}.`,
     );
 
     const provider20xFsiContents = await readFile(
@@ -1317,20 +1711,26 @@ describe("build-markdown", () => {
       "utf8",
     );
     expect(provider20xFsiContents).toContain(
-      "[FSI-CSO-NOC (Notification of Changes)](#notification-of-changes){ data-preview }",
+      firstRuleId(rules.FRR.FSI, ["all", "20x", "rev5"], ["Providers"]),
     );
 
     const fedrampFsiContents = await readFile(
       path.join(OUTPUT_DIR, "responsibilities", "fedramp-security-inbox.md"),
       "utf8",
     );
+    const fedrampSecurityInboxName = rules.FRR.FSI?.info.name;
+    expect(fedrampSecurityInboxName).toBeTruthy();
     expect(fedrampFsiContents).toStartWith(
-      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${STABLE_STATUS_SPAN}\n\n# FedRAMP Security Inbox`,
+      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${STABLE_STATUS_SPAN}\n\n# ${fedrampSecurityInboxName}`,
     );
-    expect(fedrampFsiContents).toContain("# FedRAMP Security Inbox");
+    expect(fedrampFsiContents).toContain(`# ${fedrampSecurityInboxName}`);
     expect(fedrampFsiContents).not.toContain("Effective Date(s)");
-    expect(fedrampFsiContents).toContain("FSI-FRP-VRE");
-    expect(fedrampFsiContents).not.toContain("FRC-CSO-CDS");
+    expect(fedrampFsiContents).toContain(
+      firstRuleId(rules.FRR.FSI, ["all", "20x", "rev5"], ["FedRAMP"]),
+    );
+    expect(fedrampFsiContents).not.toContain(
+      firstRuleId(rules.FRR.FRC, ["all", "20x", "rev5"], ["Providers"]),
+    );
 
     const fedrampVdrContents = await readFile(
       path.join(
@@ -1340,14 +1740,24 @@ describe("build-markdown", () => {
       ),
       "utf8",
     );
-    expect(fedrampVdrContents).toContain(
-      "# Vulnerability Detection and Response",
+    const vulnerabilityDetectionName = rules.FRR.VDR?.info.name;
+    const fedrampVdrRule = firstRuleSelection(
+      rules.FRR.VDR,
+      ["all", "20x", "rev5"],
+      ["FedRAMP"],
     );
-    expect(fedrampVdrContents).toContain("## FedRAMP Responsibilities");
+    const fedrampVdrSubsetTitle = subsetTitle(
+      rules.FRR.VDR,
+      fedrampVdrRule.bucketName,
+      fedrampVdrRule.subsetKey,
+    );
+    expect(vulnerabilityDetectionName).toBeTruthy();
+    expect(fedrampVdrContents).toContain(`# ${vulnerabilityDetectionName}`);
+    expect(fedrampVdrContents).toContain(`## ${fedrampVdrSubsetTitle}`);
     expect(fedrampVdrContents).not.toContain(
-      "## Vulnerability Detection and Response",
+      `## ${vulnerabilityDetectionName}`,
     );
-    expect(fedrampVdrContents).toContain("VDR-FRP-ARP");
+    expect(fedrampVdrContents).toContain(fedrampVdrRule.id);
 
     const agencyCcmContents = await readFile(
       path.join(
@@ -1359,25 +1769,36 @@ describe("build-markdown", () => {
       "utf8",
     );
     const collaborativeMonitoringPurpose = rules.FRR.CCM?.info.purpose;
+    const collaborativeMonitoringName = rules.FRR.CCM?.info.name;
+    const agencyCcmRule = firstRuleSelection(
+      rules.FRR.CCM,
+      ["all", "20x", "rev5"],
+      ["Agencies"],
+    );
+    const agencyCcmSubsetTitle = subsetTitle(
+      rules.FRR.CCM,
+      agencyCcmRule.bucketName,
+      agencyCcmRule.subsetKey,
+    );
     expect(collaborativeMonitoringPurpose).toBeTruthy();
+    expect(collaborativeMonitoringName).toBeTruthy();
     expect(agencyCcmContents).toStartWith(
-      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${STABLE_STATUS_SPAN}\n\n# Collaborative Continuous Monitoring`,
+      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${STABLE_STATUS_SPAN}\n\n# ${collaborativeMonitoringName}`,
     );
     expectTextOrder(
       agencyCcmContents,
       [
-        "# Collaborative Continuous Monitoring",
+        `# ${collaborativeMonitoringName}`,
         collaborativeMonitoringPurpose ?? "",
         "\n---",
-        "## Agency Guidance {#agency-guidance}",
+        `## ${agencyCcmSubsetTitle} {#${slugifyHeading(agencyCcmSubsetTitle)}}`,
       ],
       "Generated single-subset FRR markdown should place info.purpose before the first body rule without a TOC",
     );
-    expect(agencyCcmContents).toContain("# Collaborative Continuous Monitoring");
+    expect(agencyCcmContents).toContain(`# ${collaborativeMonitoringName}`);
     expect(agencyCcmContents).not.toContain("**Subsets**");
-    expect(agencyCcmContents).toContain("## Agency Guidance");
-    expect(agencyCcmContents).toContain("CCM-AGM-ROR");
-    expect(agencyCcmContents).not.toContain("## Ongoing Certification Reports");
+    expect(agencyCcmContents).toContain(`## ${agencyCcmSubsetTitle}`);
+    expect(agencyCcmContents).toContain(agencyCcmRule.id);
 
     const agencyVdrContents = await readFile(
       path.join(
@@ -1388,15 +1809,41 @@ describe("build-markdown", () => {
       ),
       "utf8",
     );
-    expect(agencyVdrContents).toContain("# Vulnerability Detection and Response");
-    expect(agencyVdrContents).toContain("## Agency Guidance");
-    expect(agencyVdrContents).toContain("VDR-AGM-RVR");
-    expect(agencyVdrContents).not.toContain("VDR-FRP-ARP");
+    expect(agencyVdrContents).toContain(`# ${vulnerabilityDetectionName}`);
+    const agencyVdrRule = firstRuleSelection(
+      rules.FRR.VDR,
+      ["all", "20x", "rev5"],
+      ["Agencies"],
+    );
+    const agencyVdrSubsetTitle = subsetTitle(
+      rules.FRR.VDR,
+      agencyVdrRule.bucketName,
+      agencyVdrRule.subsetKey,
+    );
+    expect(agencyVdrContents).toContain(`## ${agencyVdrSubsetTitle}`);
+    expect(agencyVdrContents).toContain(agencyVdrRule.id);
+    expect(agencyVdrContents).not.toContain(
+      fedrampVdrRule.id,
+    );
   });
 
   test("ignores configured rule documents after resolving the source selection", async () => {
     const config = await loadToolConfig();
-    const rules = await loadRules(config);
+    const rules = structuredClone(await loadRules(config));
+    rules.FRR = {
+      INCLUDED: testRequirementDocument({
+        name: "Included Synthetic Ruleset",
+        shortName: "INC",
+        webName: "included-synthetic-ruleset",
+        affects: ["Assessors"],
+      }),
+      IGNORED: testRequirementDocument({
+        name: "Ignored Synthetic Ruleset",
+        shortName: "IGN",
+        webName: "ignored-synthetic-ruleset",
+        affects: ["Assessors"],
+      }),
+    };
     const artifacts = collectArtifacts(rules, {
       ...config,
       generated: {
@@ -1415,7 +1862,7 @@ describe("build-markdown", () => {
             source: {
               collection: "FRR",
               documents: "ALL",
-              ignoreDocuments: ["MKT"],
+              ignoreDocuments: ["IGNORED"],
               types: ["20x"],
               affects: ["Assessors"],
               includeAll: true,
@@ -1426,13 +1873,14 @@ describe("build-markdown", () => {
       },
     });
 
-    expect(artifacts.some((artifact) => artifact.sourceDocument === "MKT")).toBe(
-      false,
-    );
+    expect(
+      artifacts.some((artifact) => artifact.sourceDocument === "IGNORED"),
+    ).toBe(false);
     expect(
       artifacts.some(
         (artifact) =>
-          artifact.relativePath === "assessors/20x/rules/marketplace-listing.md",
+          artifact.relativePath ===
+          "assessors/20x/rules/ignored-synthetic-ruleset.md",
       ),
     ).toBe(false);
   });
@@ -1440,11 +1888,18 @@ describe("build-markdown", () => {
   test("resolves related FRR links to the matching generated audience page", async () => {
     const config = await loadToolConfig();
     const rules = structuredClone(await loadRules(config));
-    const providerRule = rules.FRR.FRC?.data.all?.CSO?.["FRC-CSO-RAA"];
-    expect(providerRule).toBeTruthy();
+    const providerRule = firstRuleSelection(rules.FRR.FRC, ["all", "20x"], [
+      "Providers",
+    ]);
+    const assessorRule = firstRuleSelection(rules.FRR.FRC, ["all", "20x"], [
+      "Assessors",
+    ]);
+    const assessorRuleName = assessorRule.requirement.name ?? assessorRule.id;
 
-    providerRule!.statement = `${providerRule!.statement ?? ""} See FRC-IAS-SUM (Assessment Summary).`;
-    providerRule!.related = ["FRC-IAS-SUM"];
+    providerRule.requirement.statement = `${
+      providerRule.requirement.statement ?? ""
+    } See ${assessorRule.id} (${assessorRuleName}).`;
+    providerRule.requirement.related = [assessorRule.id];
 
     const artifacts = collectArtifacts(rules, config);
     const providerFrcArtifact = artifacts.find(
@@ -1453,16 +1908,32 @@ describe("build-markdown", () => {
     );
     const linkedRule = providerFrcArtifact?.context.sections
       .flatMap((section) => section.requirements)
-      .find((requirement) => requirement.id === "FRC-CSO-RAA");
+      .find((requirement) => requirement.id === providerRule.id);
 
     expect(linkedRule?.statementParagraphs.join("\n")).toContain(
-      "[FRC-IAS-SUM (Assessment Summary)](../../../assessors/20x/rules/fedramp-certification.md#assessment-summary){ data-preview }",
+      `[${assessorRule.id} (${assessorRuleName})](../../../assessors/20x/rules/fedramp-certification.md#${slugifyHeading(
+        assessorRuleName,
+      )}){ data-preview }`,
     );
   });
 
   test("ignores configured deadline documents after resolving the source selection", async () => {
     const config = await loadToolConfig();
-    const rules = await loadRules(config);
+    const rules = structuredClone(await loadRules(config));
+    rules.FRR = {
+      INCLUDED: testRequirementDocument({
+        name: "Included Synthetic Ruleset",
+        shortName: "INC",
+        webName: "included-synthetic-ruleset",
+        affects: ["Providers"],
+      }),
+      IGNORED: testRequirementDocument({
+        name: "Ignored Synthetic Ruleset",
+        shortName: "IGN",
+        webName: "ignored-synthetic-ruleset",
+        affects: ["Providers"],
+      }),
+    };
     const artifacts = collectArtifacts(rules, {
       ...config,
       generated: {
@@ -1478,8 +1949,8 @@ describe("build-markdown", () => {
             template: "templates/deadlines.hbs",
             source: {
               collection: "FRR",
-              documents: ["MKT", "FRC"],
-              ignoreDocuments: ["MKT"],
+              documents: ["IGNORED", "INCLUDED"],
+              ignoreDocuments: ["IGNORED"],
               types: ["20x"],
             },
           },
@@ -1500,13 +1971,27 @@ describe("build-markdown", () => {
       ) ?? [];
 
     expect(deadlineArtifact).toBeDefined();
-    expect(shortNames).toContain("FRC");
-    expect(shortNames).not.toContain("MKT");
+    expect(shortNames).toContain("INC");
+    expect(shortNames).not.toContain("IGN");
   });
 
   test("ignores deadline documents with no rules affecting the configured audience", async () => {
     const config = await loadToolConfig();
-    const rules = await loadRules(config);
+    const rules = structuredClone(await loadRules(config));
+    rules.FRR = {
+      INCLUDED: testRequirementDocument({
+        name: "Included Synthetic Ruleset",
+        shortName: "INC",
+        webName: "included-synthetic-ruleset",
+        affects: ["Providers"],
+      }),
+      FILTERED: testRequirementDocument({
+        name: "Filtered Synthetic Ruleset",
+        shortName: "FLT",
+        webName: "filtered-synthetic-ruleset",
+        affects: ["Assessors"],
+      }),
+    };
     const artifacts = collectArtifacts(rules, {
       ...config,
       generated: {
@@ -1522,7 +2007,7 @@ describe("build-markdown", () => {
             template: "templates/deadlines.hbs",
             source: {
               collection: "FRR",
-              documents: ["REC", "FRC"],
+              documents: ["INCLUDED", "FILTERED"],
               types: ["20x"],
               affects: ["Providers"],
             },
@@ -1544,7 +2029,8 @@ describe("build-markdown", () => {
       ) ?? [];
 
     expect(deadlineArtifact).toBeDefined();
-    expect(shortNames).toEqual(["FRC"]);
+    expect(shortNames).toContain("INC");
+    expect(shortNames).not.toContain("FLT");
   });
 
   test("adds page info admonitions below content pictograph spans", async () => {
@@ -2071,26 +2557,55 @@ describe("build pipeline", () => {
       await access(path.join(htmlPath, relativePath));
     }
 
+    const renderedFrcDocument = rules.FRR.FRC;
+    const renderedAgencyUseDocument = rules.FRR.AGU;
+    const renderedChangeManagementTheme = Object.values(rules.KSI).find(
+      (theme) => theme.web_name === "change-management",
+    );
+    if (
+      !renderedFrcDocument ||
+      !renderedAgencyUseDocument ||
+      !renderedChangeManagementTheme
+    ) {
+      throw new Error(
+        "Expected source documents for rendered page smoke tests to exist.",
+      );
+    }
+    const renderedDefinitionTerm =
+      Object.values(rules.FRD.data.all ?? {})
+        .map((entry) => entry.term)
+        .sort((left, right) => left.localeCompare(right))[0] ??
+      rules.FRD.info.name;
+    const renderedChangeManagementIndicatorId =
+      Object.keys(renderedChangeManagementTheme.indicators)[0] ??
+      renderedChangeManagementTheme.name;
+
     const renderedPages = [
       {
         path: "definitions/index.html",
-        expectedText: ["FedRAMP Definitions", "Cloud Service Offering"],
+        expectedText: ["FedRAMP Definitions", renderedDefinitionTerm],
       },
       {
         path: "providers/20x/rules/fedramp-certification/index.html",
-        expectedText: ["FedRAMP Certification", "FRC-CSO-CDS"],
+        expectedText: [
+          renderedFrcDocument.info.name,
+          firstRuleId(renderedFrcDocument, ["all", "20x"], ["Providers"]),
+        ],
       },
       {
         path: "providers/20x/key-security-indicators/change-management/index.html",
-        expectedText: ["Change Management", "KSI-CMT-LMC"],
+        expectedText: [
+          renderedChangeManagementTheme.name,
+          renderedChangeManagementIndicatorId,
+        ],
       },
       {
         path: "providers/updating/deadlines/20x/index.html",
-        expectedText: ["20x Deadlines", "FedRAMP Certification"],
+        expectedText: ["20x Deadlines", renderedFrcDocument.info.name],
       },
       {
         path: "agencies/rules/agency-use/index.html",
-        expectedText: ["Agency Use of FedRAMP Certified Cloud Services"],
+        expectedText: [renderedAgencyUseDocument.info.name],
       },
       {
         path: "todo/index.html",

--- a/tools/scripts/build-markdown.test.ts
+++ b/tools/scripts/build-markdown.test.ts
@@ -479,6 +479,27 @@ function subsetTitle(
   );
 }
 
+function subsetDescription(
+  document: RequirementDocumentForTest | undefined,
+  bucketName: RuleBucketForTest,
+  subsetKey: string,
+): string {
+  if (!document) {
+    throw new Error("Expected source document to exist in rules JSON.");
+  }
+
+  const versionSubset =
+    bucketName === "all"
+      ? undefined
+      : document.info[bucketName]?.subsets?.[subsetKey];
+
+  return (
+    versionSubset?.description ??
+    document.info.subsets?.[subsetKey]?.description ??
+    ""
+  );
+}
+
 function firstRuleIdsByBucket(
   document: RequirementDocumentForTest | undefined,
 ): string[] {
@@ -1069,6 +1090,7 @@ function generatedMappingStatusFailures(config: ToolConfig): string[] {
     ["ksiDocuments", config.generated.ksiDocuments ?? []],
     ["deadlineDocuments", config.generated.deadlineDocuments ?? []],
     ["referenceIndexDocuments", config.generated.referenceIndexDocuments ?? []],
+    ["frrCollectionDocuments", config.generated.frrCollectionDocuments ?? []],
     ["ruleDocuments", config.generated.ruleDocuments],
   ];
   const failures: string[] = [];
@@ -1252,11 +1274,7 @@ describe("build-markdown", () => {
       "reference/fedramp-certification.md",
       "reference/index.md",
       "reference/security-decision-record.md",
-      "responsibilities/fedramp-security-inbox.md",
-      "responsibilities/incident-communications-procedures.md",
-      "responsibilities/marketplace-listing.md",
-      "responsibilities/significant-change-notifications.md",
-      "responsibilities/vulnerability-detection-and-response.md",
+      "responsibilities/rules.md",
     ]) {
       expect(relativePaths).toContain(relativePath);
     }
@@ -1714,33 +1732,51 @@ describe("build-markdown", () => {
       firstRuleId(rules.FRR.FSI, ["all", "20x", "rev5"], ["Providers"]),
     );
 
-    const fedrampFsiContents = await readFile(
-      path.join(OUTPUT_DIR, "responsibilities", "fedramp-security-inbox.md"),
+    const fedrampResponsibilitiesContents = await readFile(
+      path.join(OUTPUT_DIR, "responsibilities", "rules.md"),
       "utf8",
     );
+    expect(fedrampResponsibilitiesContents).toStartWith(
+      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${PLACEHOLDER_STATUS_SPAN}\n\n# FedRAMP's Responsibilities`,
+    );
+    expect(fedrampResponsibilitiesContents).not.toContain("Effective Date(s)");
+    expect(fedrampResponsibilitiesContents).not.toContain("Activity Workflow");
+    expect(fedrampResponsibilitiesContents).not.toContain("``` mermaid");
+
     const fedrampSecurityInboxName = rules.FRR.FSI?.info.name;
+    const fedrampSecurityInboxPurpose = rules.FRR.FSI?.info.purpose;
+    const fedrampFsiRule = firstRuleSelection(
+      rules.FRR.FSI,
+      ["all", "20x", "rev5"],
+      ["FedRAMP"],
+    );
+    const fedrampFsiSubsetDescription = subsetDescription(
+      rules.FRR.FSI,
+      fedrampFsiRule.bucketName,
+      fedrampFsiRule.subsetKey,
+    );
     expect(fedrampSecurityInboxName).toBeTruthy();
-    expect(fedrampFsiContents).toStartWith(
-      `---\ntags:\n  - 20x\n  - Rev5\n---\n\n${STABLE_STATUS_SPAN}\n\n# ${fedrampSecurityInboxName}`,
+    expect(fedrampSecurityInboxPurpose).toBeTruthy();
+    expect(fedrampFsiSubsetDescription).toBeTruthy();
+    expectTextOrder(
+      fedrampResponsibilitiesContents,
+      [
+        "# FedRAMP's Responsibilities",
+        `## ${fedrampSecurityInboxName} {#${slugifyHeading(
+          fedrampSecurityInboxName ?? "",
+        )}}`,
+        fedrampSecurityInboxPurpose ?? "",
+        fedrampFsiSubsetDescription,
+        fedrampFsiRule.id,
+      ],
+      "Generated FedRAMP responsibilities markdown should place each FRR purpose and FRP subset description before FedRAMP rules",
     );
-    expect(fedrampFsiContents).toContain(`# ${fedrampSecurityInboxName}`);
-    expect(fedrampFsiContents).not.toContain("Effective Date(s)");
-    expect(fedrampFsiContents).toContain(
-      firstRuleId(rules.FRR.FSI, ["all", "20x", "rev5"], ["FedRAMP"]),
-    );
-    expect(fedrampFsiContents).not.toContain(
+    expect(fedrampResponsibilitiesContents).not.toContain(
       firstRuleId(rules.FRR.FRC, ["all", "20x", "rev5"], ["Providers"]),
     );
 
-    const fedrampVdrContents = await readFile(
-      path.join(
-        OUTPUT_DIR,
-        "responsibilities",
-        "vulnerability-detection-and-response.md",
-      ),
-      "utf8",
-    );
     const vulnerabilityDetectionName = rules.FRR.VDR?.info.name;
+    const vulnerabilityDetectionPurpose = rules.FRR.VDR?.info.purpose;
     const fedrampVdrRule = firstRuleSelection(
       rules.FRR.VDR,
       ["all", "20x", "rev5"],
@@ -1751,13 +1787,29 @@ describe("build-markdown", () => {
       fedrampVdrRule.bucketName,
       fedrampVdrRule.subsetKey,
     );
-    expect(vulnerabilityDetectionName).toBeTruthy();
-    expect(fedrampVdrContents).toContain(`# ${vulnerabilityDetectionName}`);
-    expect(fedrampVdrContents).toContain(`## ${fedrampVdrSubsetTitle}`);
-    expect(fedrampVdrContents).not.toContain(
-      `## ${vulnerabilityDetectionName}`,
+    const fedrampVdrSubsetDescription = subsetDescription(
+      rules.FRR.VDR,
+      fedrampVdrRule.bucketName,
+      fedrampVdrRule.subsetKey,
     );
-    expect(fedrampVdrContents).toContain(fedrampVdrRule.id);
+    expect(vulnerabilityDetectionName).toBeTruthy();
+    expect(vulnerabilityDetectionPurpose).toBeTruthy();
+    expect(fedrampVdrSubsetDescription).toBeTruthy();
+    expectTextOrder(
+      fedrampResponsibilitiesContents,
+      [
+        `## ${vulnerabilityDetectionName} {#${slugifyHeading(
+          vulnerabilityDetectionName ?? "",
+        )}}`,
+        vulnerabilityDetectionPurpose ?? "",
+        fedrampVdrSubsetDescription,
+        fedrampVdrRule.id,
+      ],
+      "Generated FedRAMP responsibilities markdown should repeat the FRR layout for later responsibility sections",
+    );
+    expect(fedrampResponsibilitiesContents).not.toContain(
+      `## ${fedrampVdrSubsetTitle}`,
+    );
 
     const agencyCcmContents = await readFile(
       path.join(
@@ -1852,6 +1904,7 @@ describe("build-markdown", () => {
         ksiDocuments: [],
         deadlineDocuments: [],
         referenceIndexDocuments: [],
+        frrCollectionDocuments: [],
         ruleDocuments: [
           {
             id: "assessor-20x-with-ignored-marketplace",
@@ -1956,6 +2009,7 @@ describe("build-markdown", () => {
           },
         ],
         referenceIndexDocuments: [],
+        frrCollectionDocuments: [],
         ruleDocuments: [],
       },
     });
@@ -2014,6 +2068,7 @@ describe("build-markdown", () => {
           },
         ],
         referenceIndexDocuments: [],
+        frrCollectionDocuments: [],
         ruleDocuments: [],
       },
     });
@@ -2107,6 +2162,7 @@ describe("build-markdown", () => {
           ksiDocuments: [],
           deadlineDocuments: [],
           referenceIndexDocuments: [],
+          frrCollectionDocuments: [],
           ruleDocuments: [],
         },
       });
@@ -2324,6 +2380,7 @@ describe("build-markdown", () => {
           ksiDocuments: [],
           deadlineDocuments: [],
           referenceIndexDocuments: [],
+          frrCollectionDocuments: [],
           ruleDocuments: [],
         },
       });
@@ -2602,6 +2659,10 @@ describe("build pipeline", () => {
       {
         path: "providers/updating/deadlines/20x/index.html",
         expectedText: ["20x Deadlines", renderedFrcDocument.info.name],
+      },
+      {
+        path: "responsibilities/rules/index.html",
+        expectedText: ["FedRAMP's Responsibilities", renderedFrcDocument.info.name],
       },
       {
         path: "agencies/rules/agency-use/index.html",

--- a/tools/scripts/build-markdown.ts
+++ b/tools/scripts/build-markdown.ts
@@ -9,6 +9,7 @@ import {
   toPosixPath,
   type DefinitionDocumentMappingConfig,
   type DeadlineDocumentMappingConfig,
+  type FrrCollectionDocumentMappingConfig,
   type GeneratedDocumentSource,
   type GeneratedDocumentStatus,
   type KsiDocumentMappingConfig,
@@ -370,6 +371,9 @@ interface RuleIndexEntry {
 }
 
 type RuleIndex = ReadonlyMap<string, RuleIndexEntry>;
+type FrrRuleSourceMappingConfig =
+  | RuleDocumentMappingConfig
+  | FrrCollectionDocumentMappingConfig;
 
 interface RulePageCandidate {
   mappingId: string;
@@ -382,7 +386,7 @@ interface RulePageCandidate {
 type RulePageIndex = ReadonlyMap<string, RulePageCandidate[]>;
 
 interface RuleLinkContext {
-  currentMapping: RuleDocumentMappingConfig;
+  currentMapping: FrrRuleSourceMappingConfig;
   currentRelativePath: string;
   ruleIndex: RuleIndex;
   rulePageIndex: RulePageIndex;
@@ -605,14 +609,14 @@ function buildRuleIndex(rules: RulesDocument): RuleIndex {
 
 function ruleBucketMatchesMapping(
   bucketName: DataBucket,
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
 ): boolean {
   return configuredBuckets(mapping).includes(bucketName);
 }
 
 function ruleSubsetMatchesMapping(
   subsetKey: string,
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
 ): boolean {
   return !mapping.source.sections || mapping.source.sections.includes(subsetKey);
 }
@@ -660,14 +664,28 @@ function buildRulePageIndex(
   ruleIndex: RuleIndex,
 ): RulePageIndex {
   const index = new Map<string, RulePageCandidate[]>();
+  const mappings: Array<{
+    mapping: FrrRuleSourceMappingConfig;
+    relativePathForDocument: (document: RequirementDocumentSource) => string;
+  }> = [
+    ...config.generated.ruleDocuments.map((mapping) => ({
+      mapping,
+      relativePathForDocument: (document: RequirementDocumentSource) =>
+        renderRuleCandidatePath(mapping, document),
+    })),
+    ...(config.generated.frrCollectionDocuments ?? []).map((mapping) => ({
+      mapping,
+      relativePathForDocument: () => normalizeGeneratedPath(mapping.output),
+    })),
+  ];
 
-  for (const mapping of config.generated.ruleDocuments) {
+  for (const { mapping, relativePathForDocument } of mappings) {
     if (mapping.source.collection !== "FRR") {
       continue;
     }
 
     for (const { key, document } of sourceDocuments(rules, mapping)) {
-      const relativePath = renderRuleCandidatePath(mapping, document);
+      const relativePath = relativePathForDocument(document);
 
       for (const [id, rule] of ruleIndex) {
         if (rule.documentKey !== key) {
@@ -1596,7 +1614,7 @@ function resolveGeneratedOutputPath(
 }
 
 function configuredBuckets(
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
 ): DataBucket[] {
   return configuredTypeBuckets(
     mapping.source.types,
@@ -1629,7 +1647,7 @@ function affectsFiltersOverlap(left: string[], right: string[]): boolean {
 
 function requirementMatchesMapping(
   requirement: RequirementEntrySource,
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
 ): boolean {
   return requirementMatchesAffectedParties(
     requirement,
@@ -1652,7 +1670,7 @@ function requirementMatchesAffectedParties(
 
 function buildConfiguredSectionViewModels(
   document: RequirementDocumentSource,
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
   doNotLinkTerms: DoNotLinkTermIndex,
   ruleLinkContext: RuleLinkContext,
 ): SectionViewModel[] {
@@ -1746,7 +1764,7 @@ function documentHasRequirementAffecting(
 
 function buildDocumentGroupedSectionViewModel(
   document: RequirementDocumentSource,
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
   doNotLinkTerms: DoNotLinkTermIndex,
   ruleLinkContext: RuleLinkContext,
 ): SectionViewModel | null {
@@ -1807,7 +1825,7 @@ function buildDocumentGroupedSectionViewModel(
 
 function sourceDocumentKeys(
   rules: RulesDocument,
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
 ): string[] {
   const { document, documents } = mapping.source;
   let selectedDocumentKeys: string[];
@@ -1840,6 +1858,7 @@ function sourceDocumentKeys(
 
 type IgnorableFrrDocumentMapping =
   | RuleDocumentMappingConfig
+  | FrrCollectionDocumentMappingConfig
   | DeadlineDocumentMappingConfig
   | ReferenceIndexDocumentMappingConfig;
 
@@ -1910,7 +1929,7 @@ interface SourceDocument {
 
 function sourceDocuments(
   rules: RulesDocument,
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
 ): SourceDocument[] {
   return sourceDocumentKeys(rules, mapping).map((documentKey) => {
     const document = rules.FRR[documentKey];
@@ -2284,7 +2303,7 @@ function buildDeadlineTables(
 
 function buildConfiguredSections(
   documents: RequirementDocumentSource[],
-  mapping: RuleDocumentMappingConfig,
+  mapping: FrrRuleSourceMappingConfig,
   doNotLinkTerms: DoNotLinkTermIndex,
   ruleLinkContext: RuleLinkContext,
 ): SectionViewModel[] {
@@ -3185,6 +3204,161 @@ function collectReferenceIndexDocumentArtifacts(
     .filter((artifact): artifact is BuildArtifact => artifact !== null);
 }
 
+function addUniqueParagraphs(target: string[], paragraphs: string[]): void {
+  const existingParagraphs = new Set(target);
+
+  for (const paragraph of paragraphs) {
+    if (existingParagraphs.has(paragraph)) {
+      continue;
+    }
+
+    target.push(paragraph);
+    existingParagraphs.add(paragraph);
+  }
+}
+
+function buildFrrCollectionSectionViewModel(
+  document: RequirementDocumentSource,
+  mapping: FrrCollectionDocumentMappingConfig,
+  doNotLinkTerms: DoNotLinkTermIndex,
+  ruleLinkContext: RuleLinkContext,
+): SectionViewModel | null {
+  const requirements: RequirementViewModel[] = [];
+  const descriptionParagraphs = splitParagraphs(document.info.purpose);
+  const allowedSections = mapping.source.sections;
+  const definitionsHref = mapping.definitionsHref ?? "definitions/";
+  const rulesHref = mapping.rulesHref ?? "";
+  const subsets = subsetsForVersions(document.info, mapping.source.types);
+
+  for (const bucketName of configuredBuckets(mapping)) {
+    const bucket = document.data[bucketName];
+    if (!bucket) {
+      continue;
+    }
+
+    for (const [subsetKey, sectionRequirements] of Object.entries(bucket)) {
+      if (allowedSections && !allowedSections.includes(subsetKey)) {
+        continue;
+      }
+
+      const matchingRequirements = Object.entries(sectionRequirements).filter(
+        ([, requirement]) => requirementMatchesMapping(requirement, mapping),
+      );
+      if (!matchingRequirements.length) {
+        continue;
+      }
+
+      addUniqueParagraphs(
+        descriptionParagraphs,
+        splitParagraphs(subsets[subsetKey]?.description),
+      );
+
+      for (const [id, requirement] of matchingRequirements) {
+        requirements.push(
+          buildRequirementViewModel(
+            id,
+            requirement,
+            definitionsHref,
+            rulesHref,
+            doNotLinkTerms,
+            ruleLinkContext,
+          ),
+        );
+      }
+    }
+  }
+
+  if (!requirements.length) {
+    return null;
+  }
+
+  return {
+    title: document.info.name,
+    anchorId: sectionAnchorId(
+      document.info.short_name ?? document.info.web_name,
+      document.info.name,
+    ),
+    anchorAttribute: sectionAnchorAttribute(
+      document.info.short_name ?? document.info.web_name,
+      document.info.name,
+    ),
+    isSubsetSection: false,
+    descriptionParagraphs,
+    requirements,
+  };
+}
+
+function collectFrrCollectionDocumentArtifact(
+  rules: RulesDocument,
+  config: ToolConfig,
+  mapping: FrrCollectionDocumentMappingConfig,
+  doNotLinkTerms: DoNotLinkTermIndex,
+  ruleIndex: RuleIndex,
+  rulePageIndex: RulePageIndex,
+): BuildArtifact | null {
+  if (mapping.source.collection !== "FRR") {
+    throw new Error(`Unsupported source collection: ${mapping.source.collection}`);
+  }
+
+  const relativePath = normalizeGeneratedPath(mapping.output);
+  const sourceDocumentEntries = sourceDocuments(rules, mapping);
+  const sections = sourceDocumentEntries
+    .map(({ document }) =>
+      buildFrrCollectionSectionViewModel(
+        document,
+        mapping,
+        doNotLinkTerms,
+        {
+          currentMapping: mapping,
+          currentRelativePath: relativePath,
+          ruleIndex,
+          rulePageIndex,
+        },
+      ),
+    )
+    .filter((section): section is SectionViewModel => section !== null);
+
+  if (!sections.length && mapping.emptyBehavior === "skip") {
+    return null;
+  }
+
+  return {
+    relativePath,
+    outputPath: resolveGeneratedOutputPath(config, relativePath),
+    templatePath: resolveToolPath(mapping.template ?? config.paths.template),
+    mappingId: mapping.id,
+    title: mapping.title,
+    documentType: "FRR",
+    context: buildDocumentContext(mapping.title, {
+      statusSpan: pictographSpan(config, mapping.status),
+      tags: versionTags(mapping.source.types),
+      isRequirementsDocument: true,
+      sections,
+    }),
+  };
+}
+
+function collectFrrCollectionDocumentArtifacts(
+  rules: RulesDocument,
+  config: ToolConfig,
+  doNotLinkTerms: DoNotLinkTermIndex,
+  ruleIndex: RuleIndex,
+  rulePageIndex: RulePageIndex,
+): BuildArtifact[] {
+  return (config.generated.frrCollectionDocuments ?? [])
+    .map((mapping) =>
+      collectFrrCollectionDocumentArtifact(
+        rules,
+        config,
+        mapping,
+        doNotLinkTerms,
+        ruleIndex,
+        rulePageIndex,
+      ),
+    )
+    .filter((artifact): artifact is BuildArtifact => artifact !== null);
+}
+
 function collectSingleRuleDocumentArtifact(
   rules: RulesDocument,
   config: ToolConfig,
@@ -3382,6 +3556,15 @@ export function collectArtifacts(
   );
   artifacts.push(...collectDeadlineDocumentArtifacts(rules, config));
   artifacts.push(...collectReferenceIndexDocumentArtifacts(rules, config));
+  artifacts.push(
+    ...collectFrrCollectionDocumentArtifacts(
+      rules,
+      config,
+      doNotLinkTerms,
+      ruleIndex,
+      rulePageIndex,
+    ),
+  );
 
   for (const mapping of config.generated.ruleDocuments) {
     artifacts.push(

--- a/tools/scripts/config.ts
+++ b/tools/scripts/config.ts
@@ -83,6 +83,19 @@ export interface RuleDocumentMappingConfig {
   source: RuleDocumentSourceConfig;
 }
 
+export interface FrrCollectionDocumentMappingConfig {
+  id: string;
+  title: string;
+  output: string;
+  status: GeneratedDocumentStatus;
+  template?: string;
+  definitionsHref?: string;
+  rulesHref?: string;
+  linkTargetScope?: RuleDocumentLinkTargetScope;
+  emptyBehavior?: GeneratedEmptyBehavior;
+  source: RuleDocumentSourceConfig;
+}
+
 export interface KsiDocumentSourceConfig {
   collection: "KSI";
   theme?: string;
@@ -152,6 +165,7 @@ export interface GeneratedConfig {
   ksiDocuments?: KsiDocumentMappingConfig[];
   deadlineDocuments?: DeadlineDocumentMappingConfig[];
   referenceIndexDocuments?: ReferenceIndexDocumentMappingConfig[];
+  frrCollectionDocuments?: FrrCollectionDocumentMappingConfig[];
   ruleDocuments: RuleDocumentMappingConfig[];
 }
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -39,15 +39,7 @@ nav = [
     "responsibilities/index.md",
     { "FedRAMP Marketplace" = "marketplace.md" },
     { "Scope of FedRAMP" = "scope.md" },
-    { "FedRAMP's Responsibilities" = [
-      { "FedRAMP Certification" = "responsibilities/fedramp-certification.md" },
-      { "FedRAMP Recognition" = "responsibilities/fedramp-recognition.md" },
-      { "FedRAMP Security Inbox" = "responsibilities/fedramp-security-inbox.md" },
-      { "Incident Communications Procedures" = "responsibilities/incident-communications-procedures.md" },
-      { "Marketplace Listing" = "responsibilities/marketplace-listing.md" },
-      { "Significant Change Notifications" = "responsibilities/significant-change-notifications.md" },
-      { "Vulnerability Detection and Response" = "responsibilities/vulnerability-detection-and-response.md" },
-    ] },
+    { "FedRAMP's Responsibilities" = "responsibilities/rules.md" },
     { "FedRAMP's Authority" = [
       { "FedRAMP Authorization Act" = [
         "authority/law/index.md",


### PR DESCRIPTION
### Content Updates

- [Federal Agencies](https://preview.fedramp.gov/2026/agencies/): Clarified that agencies must follow FedRAMP processes when using cloud services and added an oversight warning with a March 2026 CIGIE cloud computing report link.
- [The Federal Risk and Authorization Management Program](https://preview.fedramp.gov/2026/responsibilities/): Added guidance for pointing AI services at FedRAMP source data and corrected the responsibilities link to the consolidated rules page.
- [Choosing a Certification Class](https://preview.fedramp.gov/2026/providers/start/class/): Replaced the placeholder with stable guidance on how Certification Classes scale by assurance, investment, federal process maturity, and agency use cases.
- [Choosing a Certification Type](https://preview.fedramp.gov/2026/providers/start/type/): Replaced the placeholder with stable guidance comparing 20x and Rev5, including when providers should use each option and how Rev5 is expected to be retired.
- [Choosing a Certification Path](https://preview.fedramp.gov/2026/providers/start/path/): Replaced the placeholder with stable guidance explaining Program Certification and Agency Certification, including which combinations are required, limited, or unavailable.

### Site Structure

- Replaced the multi-page FedRAMP responsibilities navigation with one [FedRAMP's Responsibilities](https://preview.fedramp.gov/2026/responsibilities/rules/) page that groups FedRAMP-specific rules in one place.

### Generated Page Experience

- Added support for generated FRR collection pages, allowing selected rules from multiple rulesets to appear together on one page. Example: [FedRAMP's Responsibilities](https://preview.fedramp.gov/2026/responsibilities/rules/).
- Updated the stable-status pictograph color to a darker green for better contrast and readability.

### Tooling

- Added generator tests and documentation for FRR collection pages, related-rule links, generated references, deadline output, and rendered page smoke checks.