### PR TITLE
2026 07 06 dan updates

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -18,6 +18,11 @@ picto:
 
 This update applies some changes described in the 2026.06.25.01 release that were not previously reflected in the consolidated rules.
 
+### Content Updates
+
+- [Choosing a Certification Path](https://fedramp.gov/2026/providers/start/path/): Combined the separate Lost Sponsor and Ready Conversion sections
+  into a single Lost Sponsor/Ready Conversion pipeline description and clarified the eligibility criteria for applicants.
+
 ## 2026.07.02.01 (July 2, 2026)
 
 This update fixes several typos in the FedRAMP consolidated rules. No significant changes to requirements are included.

--- a/content/providers/start/path.md
+++ b/content/providers/start/path.md
@@ -68,49 +68,33 @@ will close on June 11, 2027, when FedRAMP stops accepting FedRAMP Rev5 Certifica
     on that date to any **Ready Conversion** or **Lost Sponsor** applicant that did not apply
     prior to that date.
 
-### Ready Conversion
+### Lost Sponsor/Ready Conversion
 
-The **Ready Conversion** application pipeline is open to cloud service providers that were
-FedRAMP Ready prior to July 28, 2026.
+As indicated by NTC-0008 there is a limited window for Program Certifications due to **Lost planned or in process sponsorship** during the heavy contract reduction period. This application pipeline is intended for cloud service providers that had begun the legacy FedRAMP authorization process with an agency sponsor (formally or informally) but were unable to complete the process for reasons that were out of their control.
 
 - **Opens:** August 10, 2026
 - **CR26 Grace Period Ends:** February 19, 2027
 - Available for **Class B** or **Class C**
 
-Applicants may submit an fresh version of their legacy FedRAMP Ready submission to qualify for
-a Class B or Class C Certification (pilot) with an agreement to follow all updated rules for FedRAMP
-Rev5 by February 19, 2027.
+To qualify for this pipeline, a cloud service provider must have met **one** of the following criteria between **January 2025 and March 2026**:
 
-!!! info "FedRAMP must confirm eligibility prior to submission."
+- Was In Process on the FedRAMP Marketplace but lost sponsorship. [Lost Sponsor]
+
+- Completed a full FedRAMP assessment with a Security Assessment Plan and Security Assessment Report (SAP/SAR) under an informal agreement with an agency to initiate In Process once it was complete. [Lost Sponsor]
+
+- Completed a FedRAMP Ready assessment with a Readiness Assessment (RAR) during the above timeframe [Conversion]
+
+- Achieved FedRAMP Ready on the FR Marketplace during the above timeframe [Conversion]
+
+Applicants may submit a fresh version of their legacy FedRAMP Rev5 materials, including a completed assessment (if it was not completed), to qualify for a Class B or Class C Certification (pilot) with an agreement to follow all updated rules for FedRAMP Rev5 by February 19, 2027.
+
+!!! info "FedRAMP must confirm eligibility prior to submission. Please provide qualification evidence along with the required form. FedRAMP will reach out to you directly."
 
     To confirm eligibility, fill out the "[[For CSPs] Ready Conversion Form](https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=52069750514459)".
 
-### Lost Sponsor
-
-The **Lost Sponsor** application pipeline is intended for cloud service providers that had
-begun the legacy FedRAMP authorization process with an agency sponsor but were unable to complete
-the process for reasons that were out of their control (typically because the agency canceled
-the sponsorship due to budget cuts).
-
-- **Opens:** August 10, 2026
-- **CR26 Grace Period Ends:** February 19, 2027
-- Available for **Class B** or **Class C**
-
-To qualify for this pipeline, a cloud service provider must have met **one** of the following
-criteria between January 2025 and March 2026:
-
-- Was In Process on the FedRAMP Marketplace but lost sponsorship.
-- Completed a full FedRAMP assessment with a Security Assessment Plan and Security Assessment
-  Report (SAP/SAR) under an informal agreement with an agency to initiate In Process once it
-  was complete.
-
-Applicants may submit a fresh version of their legacy FedRAMP Rev5 materials, including a
-completed assessment (if it was not completed), to qualify for a Class B or Class C Certification
-(pilot) with an agreement to follow all updated rules for FedRAMP Rev5 by February 19, 2027.
-
-!!! info "FedRAMP must confirm eligibility prior to submission."
-
     To confirm eligibility, fill out the "[[For CSPs] Lost Sponsor Form](https://help.fedramp.gov/hc/en-us/requests/new?ticket_form_id=52061181133979)".
+
+    
 
 
 

--- a/tools/.tool-versions
+++ b/tools/.tool-versions
@@ -1,0 +1,2 @@
+python 3.12.7
+bun system

--- a/tools/scripts/build.ts
+++ b/tools/scripts/build.ts
@@ -2,7 +2,12 @@ import { spawn } from "node:child_process";
 import { rm } from "node:fs/promises";
 import path from "node:path";
 import { buildMarkdown } from "./build-markdown";
-import { REPO_ROOT, loadToolConfig, resolveToolPath } from "./config";
+import {
+  REPO_ROOT,
+  loadToolConfig,
+  resolveToolPath,
+  zensicalCommand,
+} from "./config";
 import { deploy } from "./deploy";
 
 function runCommand(command: string, args: string[]): Promise<void> {
@@ -42,11 +47,12 @@ async function main(): Promise<void> {
   }
 
   await rm(path.join(REPO_ROOT, ".cache"), { recursive: true, force: true });
-  await runCommand("zensical", [
+  const zensical = zensicalCommand(
     "build",
     "-f",
     resolveToolPath(config.paths.zensicalConfig),
-  ]);
+  );
+  await runCommand(zensical.command, zensical.args);
 }
 
 main().catch((error) => {

--- a/tools/scripts/config.ts
+++ b/tools/scripts/config.ts
@@ -263,6 +263,15 @@ export function relativeToTools(absolutePath: string): string {
   return path.relative(TOOLS_DIR, absolutePath);
 }
 
+// zensical is installed into the project's uv-managed venv (see tools/README.md),
+// not onto the ambient PATH, so subprocesses need to invoke it through `uv run`.
+export function zensicalCommand(...args: string[]): { command: string; args: string[] } {
+  return {
+    command: "uv",
+    args: ["run", "--project", TOOLS_DIR, "zensical", ...args],
+  };
+}
+
 export function toPosixPath(filePath: string): string {
   return filePath.split(path.sep).join("/");
 }

--- a/tools/scripts/dev.ts
+++ b/tools/scripts/dev.ts
@@ -9,6 +9,7 @@ import {
   REPO_ROOT,
   loadToolConfig,
   resolveToolPath,
+  zensicalCommand,
 } from "./config";
 import { deploy } from "./deploy";
 
@@ -451,7 +452,8 @@ async function main(): Promise<void> {
 
   const trackContentChange = createContentChangeTracker(contentDir);
 
-  const zensical = spawn("zensical", ["serve", "-f", zensicalConfig], {
+  const zensicalServe = zensicalCommand("serve", "-f", zensicalConfig);
+  const zensical = spawn(zensicalServe.command, zensicalServe.args, {
     cwd: REPO_ROOT,
     stdio: "inherit",
   });


### PR DESCRIPTION
- **Consolidate "Lost Sponsor" and "Ready Conversion" sections; revise eligibility criteria and streamline content for clarity.**
- **Refactor zensical invocations to use centralized `zensicalCommand` utility; update `.tool-versions` with Python and Bun versions.**
- **Combined the separate Lost Sponsor and Ready Conversion sections   into a single Lost Sponsor/Ready Conversion pipeline description and clarified the eligibility criteria for applicants.**
